### PR TITLE
Improve svc lift

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1156,11 +1156,18 @@ public:
 
 	virtual string GetRegisterName(uint32_t reg) override
 	{
-		if (reg == REG_NONE)
+		switch (reg) {
+		case REG_NONE:
 			return "";
+		case FAKEREG_SYSCALL_IMM:
+			return "syscall_imm";
+		}
+
 		const char* regName = get_register_name((enum Register)reg);
+
 		if (!regName)
 			return "";
+
 		return regName;
 	}
 
@@ -1220,6 +1227,9 @@ public:
 		// this could also be inlined, but the odds of more status registers being added
 		// seems high, and updatingthem multiple places would be a pain
 		for (uint32_t ii = SYSREG_NONE + 1; ii < SYSREG_END; ++ii)
+			r.push_back(ii);
+
+		for (uint32_t ii = FAKEREG_NONE + 1; ii < FAKEREG_END; ++ii)
 			r.push_back(ii);
 
 		return r;
@@ -1512,6 +1522,8 @@ public:
 			case REG_Q30:
 			case REG_Q31:
 				return RegisterInfo(reg, 0, 16);
+			case FAKEREG_SYSCALL_IMM:
+				return RegisterInfo(reg, 0, 2);
 		}
 
 		if (reg > SYSREG_NONE && reg < SYSREG_END)
@@ -1877,6 +1889,38 @@ public:
 	}
 };
 
+class WindowsArm64SystemCallConvention: public CallingConvention
+{
+public:
+	WindowsArm64SystemCallConvention(Architecture* arch): CallingConvention(arch, "windows-syscall")
+	{
+	}
+
+
+	virtual vector<uint32_t> GetIntegerArgumentRegisters() override
+	{
+		return { FAKEREG_SYSCALL_IMM };
+	}
+
+
+	virtual vector<uint32_t> GetCallerSavedRegisters() override
+	{
+		return vector<uint32_t>{ REG_X0 };
+	}
+
+
+	virtual vector<uint32_t> GetCalleeSavedRegisters() override
+	{
+		return {};
+	}
+
+
+	virtual uint32_t GetIntegerReturnValueRegister() override
+	{
+		return REG_X0;
+	}
+};
+
 
 class Arm64MachoRelocationHandler: public RelocationHandler
 {
@@ -2228,6 +2272,9 @@ extern "C"
 		arm64->SetStdcallCallingConvention(conv);
 
 		conv = new LinuxArm64SystemCallConvention(arm64);
+		arm64->RegisterCallingConvention(conv);
+
+		conv = new WindowsArm64SystemCallConvention(arm64);
 		arm64->RegisterCallingConvention(conv);
 
 		// Register ARM64 specific PLT trampoline recognizer

--- a/il.cpp
+++ b/il.cpp
@@ -1103,10 +1103,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 					instr.operation == ARM64_SUBS ? IL_FLAGWRITE_ALL : 0)));
 		break;
 	case ARM64_SVC:
-		if (instr.operands[0].immediate == 0)
-			il.AddInstruction(il.SystemCall());
-		else
-			il.AddInstruction(il.Unimplemented());
+		il.AddInstruction(il.SetRegister(2, FAKEREG_SYSCALL_IMM, il.Const(2, IMM(operand1))));
+		il.AddInstruction(il.SystemCall());
 		break;
 	case ARM64_SXTB:
 		il.AddInstruction(il.SetRegister(REGSZ(operand1), REG(operand1),

--- a/il.h
+++ b/il.h
@@ -35,6 +35,13 @@ enum Arm64Intrinsic : uint32_t
 	ARM64_INTRIN_DSB,
 };
 
+enum Arm64FakeRegister: uint32_t
+{
+	FAKEREG_NONE = arm64::SYSREG_END + 1,
+	FAKEREG_SYSCALL_IMM,
+	FAKEREG_END,
+};
+
 bool GetLowLevelILForInstruction(
 		BinaryNinja::Architecture* arch,
 		uint64_t addr,


### PR DESCRIPTION
While linux stores the syscall number in `x8`, Windows makes use of the
16bit immediate in the instruction encoding to do the same thing. This
updates the lift to handle this case.

The LLIL_SYSCALL operation takes no arguments, so to encode the syscall
number on Windows platforms I added a new fake register, which also got
added to the calling convention.