### PR TITLE
Lift prfm, prfum

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -867,6 +867,8 @@ public:
 			return "__dmb";
 		case ARM64_INTRIN_DSB:
 			return "__dsb";
+		case ARM64_INTRIN_PRFM:
+			return "__prefetch";
 		default:
 			return "";
 		}
@@ -879,7 +881,8 @@ public:
 			ARM64_INTRIN_MSR, ARM64_INTRIN_MRS, ARM64_INTRIN_HINT_NOP, ARM64_INTRIN_HINT_YIELD,
 			ARM64_INTRIN_HINT_WFE, ARM64_INTRIN_HINT_WFI, ARM64_INTRIN_HINT_SEV, ARM64_INTRIN_HINT_SEVL,
 			ARM64_INTRIN_HINT_DGH, ARM64_INTRIN_HINT_ESB, ARM64_INTRIN_HINT_PSB, ARM64_INTRIN_HINT_TSB,
-			ARM64_INTRIN_HINT_CSDB, ARM64_INTRIN_HINT_BTI, ARM64_INTRIN_SEV, ARM64_INTRIN_DMB, ARM64_INTRIN_DSB};
+			ARM64_INTRIN_HINT_CSDB, ARM64_INTRIN_HINT_BTI, ARM64_INTRIN_SEV, ARM64_INTRIN_DMB, ARM64_INTRIN_DSB,
+			ARM64_INTRIN_PRFM};
 	}
 
 
@@ -891,6 +894,8 @@ public:
 			return {NameAndType(Type::IntegerType(8, false))};
 		case ARM64_INTRIN_MRS:
 			return {NameAndType(Type::IntegerType(4, false))};
+		case ARM64_INTRIN_PRFM:
+			return {NameAndType(Type::IntegerType(8, false))};
 		case ARM64_INTRIN_ISB:
 		case ARM64_INTRIN_WFE:
 		case ARM64_INTRIN_WFI:
@@ -941,6 +946,7 @@ public:
 		case ARM64_INTRIN_SEV:
 		case ARM64_INTRIN_DMB:
 		case ARM64_INTRIN_DSB:
+		case ARM64_INTRIN_PRFM:
 		default:
 			return vector<Confidence<Ref<Type>>>();
 		}

--- a/arm64test.py
+++ b/arm64test.py
@@ -3,6 +3,7 @@
 RET = b'\xc0\x03\x5f\xd6'
 
 test_cases = [
+	(b'\x21\xf0\x9f\xf8', 'LLIL_INTRINSIC([],__prefetch,LLIL_CALL_PARAM([<il: [x1 - 1].q>]))'), # prfum   pldl1strm, [x1, #-0x1]
 	(b'\x21\x00\x80\xf9', 'LLIL_INTRINSIC([],__prefetch,LLIL_CALL_PARAM([<il: [x1].q>]))'), # prfm    pldl1strm, [x1]
 	(b'\x41\x7c\xc3\x9b', 'LLIL_SET_REG(x1,LLIL_LSR(LLIL_MULU_DP(LLIL_REG(x2),LLIL_REG(x3)),LLIL_CONST(8)))'), # umulh x1, x2, x3
 	(b'\x41\x7c\x43\x9b', 'LLIL_SET_REG(x1,LLIL_LSR(LLIL_MULS_DP(LLIL_REG(x2),LLIL_REG(x3)),LLIL_CONST(8)))'), # smulh x1, x2, x3

--- a/arm64test.py
+++ b/arm64test.py
@@ -3,6 +3,7 @@
 RET = b'\xc0\x03\x5f\xd6'
 
 test_cases = [
+	(b'\x21\x00\x80\xf9', 'LLIL_INTRINSIC([],__prefetch,LLIL_CALL_PARAM([<il: [x1].q>]))'), # prfm    pldl1strm, [x1]
 	(b'\x41\x7c\xc3\x9b', 'LLIL_SET_REG(x1,LLIL_LSR(LLIL_MULU_DP(LLIL_REG(x2),LLIL_REG(x3)),LLIL_CONST(8)))'), # umulh x1, x2, x3
 	(b'\x41\x7c\x43\x9b', 'LLIL_SET_REG(x1,LLIL_LSR(LLIL_MULS_DP(LLIL_REG(x2),LLIL_REG(x3)),LLIL_CONST(8)))'), # smulh x1, x2, x3
 	(b'\x41\x7c\x23\x9b', 'LLIL_SET_REG(x1,LLIL_MULS_DP(LLIL_REG(w2),LLIL_REG(w3)))'), # smull x1, w2, w3

--- a/il.cpp
+++ b/il.cpp
@@ -1027,6 +1027,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 	case ARM64_NOP:
 		il.AddInstruction(il.Nop());
 		break;
+	case ARM64_PRFUM:
 	case ARM64_PRFM:
 		// TODO use the PRFM types when we have a better option than defining 18 different intrinsics to account for:
 		// - 3 types {PLD, PLI, PST}

--- a/il.cpp
+++ b/il.cpp
@@ -184,7 +184,6 @@ static size_t ReadILOperand(LowLevelILFunction& il, InstructionOperand& operand,
 			return il.Const(resultSize, operand.immediate);
 	case LABEL:
 		return il.ConstPointer(8, operand.immediate);
-	//case FIMM32:
 	case REG:
 		if (operand.reg[0] == REG_WZR || operand.reg[0] == REG_XZR)
 			return il.Const(resultSize, 0);
@@ -1027,6 +1026,13 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		break;
 	case ARM64_NOP:
 		il.AddInstruction(il.Nop());
+		break;
+	case ARM64_PRFM:
+		// TODO use the PRFM types when we have a better option than defining 18 different intrinsics to account for:
+		// - 3 types {PLD, PLI, PST}
+		// - 3 targets {L1, L2, L3}
+		// - 2 policies {KEEP, STM}
+		il.AddInstruction(il.Intrinsic({}, ARM64_INTRIN_PRFM, {ReadILOperand(il, operand2, 8)}));
 		break;
 	case ARM64_ORN:
 		il.AddInstruction(il.SetRegister(REGSZ(operand1), REG(operand1),

--- a/il.h
+++ b/il.h
@@ -33,6 +33,7 @@ enum Arm64Intrinsic : uint32_t
 	ARM64_INTRIN_SEV,
 	ARM64_INTRIN_DMB,
 	ARM64_INTRIN_DSB,
+	ARM64_INTRIN_PRFM,
 };
 
 enum Arm64FakeRegister: uint32_t


### PR DESCRIPTION
Similiar to `dsb`/`dmb`, this intrinsic takes a variety of args to
determine how exactly to prefetch. Until we can define types in the
architecture, just lift this as a single intrinsic.