### PR TITLE
Fix syscall branch for non-zero immediates

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -399,8 +399,7 @@ protected:
 			break;
 
 		case ARM64_SVC:
-			if (instr.operands[0].immediate == 0)
-				result.AddBranch(SystemCall);
+			result.AddBranch(SystemCall);
 			break;
 
 		default:


### PR DESCRIPTION
Windows and possibly other arm64 platforms can use the immediate field
for syscalls.