### PR TITLE
Increase system register size

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -966,7 +966,7 @@ public:
 		switch (intrinsic)
 		{
 		case ARM64_INTRIN_MRS:
-			return {NameAndType(Type::IntegerType(4, false))};
+			return {NameAndType(Type::IntegerType(8, false))};
 		case ARM64_INTRIN_AUTDA: // reads <Xn|SP>
 		case ARM64_INTRIN_AUTDB: // reads <Xn|SP>
 		case ARM64_INTRIN_AUTIA: // reads <Xn|SP>
@@ -997,7 +997,7 @@ public:
 		switch (intrinsic)
 		{
 		case ARM64_INTRIN_MSR:
-			return {Type::IntegerType(4, false)};
+			return {Type::IntegerType(8, false)};
 		case ARM64_INTRIN_AUTDA: // writes <Xd>
 		case ARM64_INTRIN_AUTDB: // writes <Xd>
 		case ARM64_INTRIN_AUTIA: // writes <Xd>
@@ -1768,7 +1768,7 @@ public:
 		}
 
 		if (reg > SYSREG_NONE && reg < SYSREG_END)
-			return RegisterInfo(reg, 0, 4);
+			return RegisterInfo(reg, 0, 8);
 
 		return RegisterInfo(0, 0, 0);
 	}


### PR DESCRIPTION
8 bytes is too big for some of these, but at least one (FAR_EL1) is 64
bit. Rather than try to figure out which are 32 vs 64, just make them
all 64 and call it a day.