### PR TITLE
Fix sbcs, bics flag lift, lift carry flag for LLIL_AND

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1295,7 +1295,6 @@ public:
 		switch (op)
 		{
 			case LLIL_AND:
-			{
 				switch (flag) {
 					case IL_FLAG_V:
 						return il.CompareNotEqual(0,
@@ -1306,26 +1305,14 @@ public:
 									il.Flag(IL_FLAG_V)),
 								il.Const(0, 0));
 				}
-			}
-			break;
-
 			case LLIL_SBB:
-			{
 				switch (flag) {
 					case IL_FLAG_C:
-						return il.CompareUnsignedLessThan(size,
-								il.AddCarry(size,
-									il.GetExprForRegisterOrConstant(operands[0], size),
-									il.GetExprForRegisterOrConstant(operands[1], size),
-									il.Flag(IL_FLAG_C)),
+						return il.CompareUnsignedGreaterThan(size,
+								il.GetExprForRegisterOrConstantOperation(op, size, operands, operandCount),
 								il.GetExprForRegisterOrConstant(operands[0], size));
 
 				}
-			}
-			break;
-
-			default:
-			break;
 		}
 
 		BNFlagRole role = GetFlagRole(flag, GetSemanticClassForFlagWriteType(flagWriteType));

--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1308,9 +1308,16 @@ public:
 			case LLIL_SBB:
 				switch (flag) {
 					case IL_FLAG_C:
-						return il.CompareUnsignedGreaterThan(size,
-								il.GetExprForRegisterOrConstantOperation(op, size, operands, operandCount),
-								il.GetExprForRegisterOrConstant(operands[0], size));
+						// r u< a || (r == a && flag_c)
+						return il.Or(0,
+								il.CompareUnsignedLessThan(size,
+									il.GetExprForRegisterOrConstantOperation(op, size, operands, operandCount),
+									il.GetExprForRegisterOrConstant(operands[0], size)),
+								il.And(0,
+									il.CompareEqual(size,
+										il.GetExprForRegisterOrConstantOperation(op, size, operands, operandCount),
+										il.GetExprForRegisterOrConstant(operands[0], size)),
+									il.Flag(IL_FLAG_C)));
 
 				}
 		}

--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1304,6 +1304,8 @@ public:
 										il.Const(size, 0)),
 									il.Flag(IL_FLAG_V)),
 								il.Const(0, 0));
+					case IL_FLAG_C:
+						return il.Const(0, 0);
 				}
 			case LLIL_SBB:
 				switch (flag) {

--- a/il.cpp
+++ b/il.cpp
@@ -892,8 +892,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 					il.And(REGSZ(operand2),
 						ILREG(operand2),
 						il.Not(REGSZ(operand2),
-							ReadILOperand(il, operand3, REGSZ(operand2)), SETFLAGS)
-							)));
+							ReadILOperand(il, operand3, REGSZ(operand2))), SETFLAGS)
+							));
 		break;
 	case ARM64_CBNZ:
 		ConditionalJump(arch, il,


### PR DESCRIPTION
Just creating this so I don't forget about it again, not urgent in the least. I think this is correct, and hopefully the final one. The thing that made this click a bit more for me, is because at it's core it's an negation + addition, if the result is less than the input then the carry would be set. The only tricky case is is if the result is equal to input, in which case the carry out depends on carry in.

Here is a dumb informal table I collected of some values to make sure I understood this a bit more:
```
sbcs 41, -1, 1 = 42 / 0
sbcs 41, -1, 0 = 41 / 0
sbcs 41,  1, 1 = 40 / 1
sbcs 41,  1, 0 = 3f / 1
sbcs 41,  0, 1 = 41 / 1
sbcs 41,  0, 0 = 40 / 1
sbcs -1, 41, 1 = ffbe / 1
sbcs -1, 41, 0 = ffbd / 1
sbcs  1, 41, 1 = ffc0 / 0
sbcs  1, 41, 0 = ffbf / 0
```