### PR TITLE
Lift ld1, lift st1, fix previous vector/simd instructions

### DIFF
--- a/arm64test.py
+++ b/arm64test.py
@@ -3,10 +3,14 @@
 RET = b'\xc0\x03\x5f\xd6'
 
 test_cases = [
+	(b'\x00\x70\x00\x4c', 'LLIL_STORE.o(LLIL_REG.q(x0),LLIL_REG.o(v0))'), # st1 {v0.16b}, [x0]
+	(b'\x00\xa0\x00\x4c', 'LLIL_STORE.o(LLIL_REG.q(x0),LLIL_REG.o(v0)); LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x10)),LLIL_REG.o(v1))'), # st1 {v0.16b, v1.16b}, [x0]
+	(b'\x00\x60\x00\x4c', 'LLIL_STORE.o(LLIL_REG.q(x0),LLIL_REG.o(v0)); LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x10)),LLIL_REG.o(v1)); LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x20)),LLIL_REG.o(v2))'), # st1 {v0.16b, v1.16b, v2.16b}, [x0]
+	(b'\x00\x20\x00\x4c', 'LLIL_STORE.o(LLIL_REG.q(x0),LLIL_REG.o(v0)); LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x10)),LLIL_REG.o(v1)); LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x20)),LLIL_REG.o(v2)); LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x30)),LLIL_REG.o(v3))'), # st1 {v0.16b, v1.16b, v2.16b, v3.16b}, [x0]
 	(b'\x00\x70\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b}, [x0]
-	(b'\x00\xa0\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b}, [x0]
-	(b'\x00\x60\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v2,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b}, [x0]
-	(b'\x00\x20\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v2,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v3,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b, v3.16b}, [x0]
+	(b'\x00\xa0\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x10))))'), # ld1 {v0.16b, v1.16b}, [x0]
+	(b'\x00\x60\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x10)))); LLIL_SET_REG.o(v2,LLIL_LOAD.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x20))))'), # ld1 {v0.16b, v1.16b, v2.16b}, [x0]
+	(b'\x00\x20\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x10)))); LLIL_SET_REG.o(v2,LLIL_LOAD.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x20)))); LLIL_SET_REG.o(v3,LLIL_LOAD.o(LLIL_ADD.q(LLIL_REG.q(x0),LLIL_CONST.b(0x30))))'), # ld1 {v0.16b, v1.16b, v2.16b, v3.16b}, [x0]
 	(b'\x63\x86\xa3\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_REG.q(x1),LLIL_MULU_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # umsubl  x3, w19, w3, x1
 	(b'\x63\xfe\xa3\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_CONST.q(0x0),LLIL_MULU_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # umnegl  x3, w19, w3
 	(b'\x63\x86\x23\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_REG.q(x1),LLIL_MULS_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # smsubl  x3, w19, w3, x1

--- a/arm64test.py
+++ b/arm64test.py
@@ -3,10 +3,10 @@
 RET = b'\xc0\x03\x5f\xd6'
 
 test_cases = [
-	(b'\x00\x70\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b}, [x0]
-	(b'\x00\xa0\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v1,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b}, [x0]
-	(b'\x00\x60\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v1,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v2,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b}, [x0]
-	(b'\x00\x20\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v1,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v2,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v3,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b, v3.16b}, [x0]
+	(b'\x00\x70\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b}, [x0]
+	(b'\x00\xa0\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b}, [x0]
+	(b'\x00\x60\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v2,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b}, [x0]
+	(b'\x00\x20\x40\x4c', 'LLIL_SET_REG.o(v0,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v1,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v2,LLIL_LOAD.o(LLIL_REG.q(x0))); LLIL_SET_REG.o(v3,LLIL_LOAD.o(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b, v3.16b}, [x0]
 	(b'\x63\x86\xa3\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_REG.q(x1),LLIL_MULU_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # umsubl  x3, w19, w3, x1
 	(b'\x63\xfe\xa3\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_CONST.q(0x0),LLIL_MULU_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # umnegl  x3, w19, w3
 	(b'\x63\x86\x23\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_REG.q(x1),LLIL_MULS_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # smsubl  x3, w19, w3, x1
@@ -17,7 +17,7 @@ test_cases = [
 	(b'\x20\x00\x02\x9a', 'LLIL_SET_REG.q(x0,LLIL_ADC.q(LLIL_REG.q(x1),LLIL_REG.q(x2),LLIL_FLAG(c)))'), # adc x0, x1, x2
 	(b'\x20\x00\x02\xba', 'LLIL_SET_REG.q(x0,LLIL_ADC.q(LLIL_REG.q(x1),LLIL_REG.q(x2),LLIL_FLAG(c)))'), # adcs x0, x1, x2
 	(b'\x08\x75\x93\x13', 'LLIL_SET_REG.d(w8,LLIL_LSR.q(LLIL_OR.q(LLIL_LSL.q(LLIL_REG.d(w8),LLIL_CONST.b(0x20)),LLIL_REG.d(w19)),LLIL_CONST.b(0x1D)))'), # extr    w8, w8, w19, #0x1d
-	(b'\x20\x28\xc2\x93', 'LLIL_SET_REG.q(x0,LLIL_LSR.128(LLIL_OR.128(LLIL_LSL.128(LLIL_REG.q(x1),LLIL_CONST.b(0x40)),LLIL_REG.q(x2)),LLIL_CONST.b(0xA)))'), # extr x0, x1, x2, #10
+	(b'\x20\x28\xc2\x93', 'LLIL_SET_REG.q(x0,LLIL_LSR.o(LLIL_OR.o(LLIL_LSL.o(LLIL_REG.q(x1),LLIL_CONST.b(0x40)),LLIL_REG.q(x2)),LLIL_CONST.b(0xA)))'), # extr x0, x1, x2, #10
 	(b'\xc6\x0c\xc0\xda', 'LLIL_INTRINSIC([x6],_byteswap,LLIL_CALL_PARAM([LLIL_REG.q(x6)]))'), # rev x6, x6
 	(b'\xcb\x10\xc0\xda', 'LLIL_INTRINSIC([x11],_CountLeadingZeros,LLIL_CALL_PARAM([LLIL_REG.q(x6)]))'), # clz     x11, x6
 	(b'\x63\x00\xc0\xda', 'LLIL_INTRINSIC([x3],__rbit,LLIL_CALL_PARAM([LLIL_REG.q(x3)]))'), # rbit    x3, x3
@@ -198,8 +198,8 @@ test_cases = [
 	(b'\x2C\x59\x22\xFC', 'LLIL_STORE.q(LLIL_ADD.q(LLIL_REG.q(x9),LLIL_LSL.q(LLIL_ZX.q(LLIL_REG.d(w2)),LLIL_CONST.b(0x3))),LLIL_REG.q(d12))'), # str d12, [x9, w2, uxtw #3]
 	(b'\x25\xD9\x22\xFC', 'LLIL_STORE.q(LLIL_ADD.q(LLIL_REG.q(x9),LLIL_LSL.q(LLIL_SX.q(LLIL_REG.d(w2)),LLIL_CONST.b(0x3))),LLIL_REG.q(d5))'), # str d5, [x9, w2, sxtw #3]
 	# STR_Q_ldst_regoff 00111100101xxxxxx1xx10xxxxxxxxxx
-	(b'\x0B\xCB\xA1\x3C', 'LLIL_STORE.128(LLIL_ADD.q(LLIL_REG.q(x24),LLIL_SX.q(LLIL_REG.d(w1))),LLIL_REG.128(q11))'), # str q11, [x24, w1, sxtw]
-	(b'\x8E\xCB\xBD\x3C', 'LLIL_STORE.128(LLIL_ADD.q(LLIL_REG.q(x28),LLIL_SX.q(LLIL_REG.d(w29))),LLIL_REG.128(q14))'), # str q14, [x28, w29, sxtw]
+	(b'\x0B\xCB\xA1\x3C', 'LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x24),LLIL_SX.q(LLIL_REG.d(w1))),LLIL_REG.o(q11))'), # str q11, [x24, w1, sxtw]
+	(b'\x8E\xCB\xBD\x3C', 'LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x28),LLIL_SX.q(LLIL_REG.d(w29))),LLIL_REG.o(q14))'), # str q14, [x28, w29, sxtw]
 	# IFORM: STR_imm_fpsimd (class post_indexed)
 	# STR_B_ldst_immpost 00111100000xxxxxxxxx01xxxxxxxxxx
 	(b'\xB6\x57\x07\x3C', 'LLIL_STORE.b(LLIL_REG.q(x29),LLIL_REG.b(b22)); LLIL_SET_REG.q(x29,LLIL_ADD.q(LLIL_REG.q(x29),LLIL_CONST.q(0x75)))'), # str b22, [x29], #117
@@ -214,8 +214,8 @@ test_cases = [
 	(b'\xAD\xE4\x1F\xFC', 'LLIL_STORE.q(LLIL_REG.q(x5),LLIL_REG.q(d13)); LLIL_SET_REG.q(x5,LLIL_ADD.q(LLIL_REG.q(x5),LLIL_CONST.q(0xFFFFFFFFFFFFFFFE)))'), # str d13, [x5], #-2
 	(b'\xE3\x64\x15\xFC', 'LLIL_STORE.q(LLIL_REG.q(x7),LLIL_REG.q(d3)); LLIL_SET_REG.q(x7,LLIL_ADD.q(LLIL_REG.q(x7),LLIL_CONST.q(0xFFFFFFFFFFFFFF56)))'), # str d3, [x7], #-170
 	# STR_Q_ldst_immpost 00111100100xxxxxxxxx01xxxxxxxxxx
-	(b'\xAD\xA5\x9A\x3C', 'LLIL_STORE.128(LLIL_REG.q(x13),LLIL_REG.128(q13)); LLIL_SET_REG.q(x13,LLIL_ADD.q(LLIL_REG.q(x13),LLIL_CONST.q(0xFFFFFFFFFFFFFFAA)))'), # str q13, [x13], #-86
-	(b'\x6C\x15\x8B\x3C', 'LLIL_STORE.128(LLIL_REG.q(x11),LLIL_REG.128(q12)); LLIL_SET_REG.q(x11,LLIL_ADD.q(LLIL_REG.q(x11),LLIL_CONST.q(0xB1)))'), # str q12, [x11], #177
+	(b'\xAD\xA5\x9A\x3C', 'LLIL_STORE.o(LLIL_REG.q(x13),LLIL_REG.o(q13)); LLIL_SET_REG.q(x13,LLIL_ADD.q(LLIL_REG.q(x13),LLIL_CONST.q(0xFFFFFFFFFFFFFFAA)))'), # str q13, [x13], #-86
+	(b'\x6C\x15\x8B\x3C', 'LLIL_STORE.o(LLIL_REG.q(x11),LLIL_REG.o(q12)); LLIL_SET_REG.q(x11,LLIL_ADD.q(LLIL_REG.q(x11),LLIL_CONST.q(0xB1)))'), # str q12, [x11], #177
 	# IFORM: STR_imm_fpsimd (class pre_indexed)
 	# STR_B_ldst_immpre 00111100000xxxxxxxxx11xxxxxxxxxx
 	(b'\x26\xBF\x00\x3C', 'LLIL_SET_REG.q(x25,LLIL_ADD.q(LLIL_REG.q(x25),LLIL_CONST.q(0xB))); LLIL_STORE.b(LLIL_REG.q(x25),LLIL_REG.b(b6))'), # str b6, [x25, #11]!
@@ -230,8 +230,8 @@ test_cases = [
 	(b'\x04\xEF\x1B\xFC', 'LLIL_SET_REG.q(x24,LLIL_ADD.q(LLIL_REG.q(x24),LLIL_CONST.q(0xFFFFFFFFFFFFFFBE))); LLIL_STORE.q(LLIL_REG.q(x24),LLIL_REG.q(d4))'), # str d4, [x24, #-66]!
 	(b'\x71\x6F\x1A\xFC', 'LLIL_SET_REG.q(x27,LLIL_ADD.q(LLIL_REG.q(x27),LLIL_CONST.q(0xFFFFFFFFFFFFFFA6))); LLIL_STORE.q(LLIL_REG.q(x27),LLIL_REG.q(d17))'), # str d17, [x27, #-90]!
 	# STR_Q_ldst_immpre 00111100100xxxxxxxxx11xxxxxxxxxx
-	(b'\x8B\x8D\x93\x3C', 'LLIL_SET_REG.q(x12,LLIL_ADD.q(LLIL_REG.q(x12),LLIL_CONST.q(0xFFFFFFFFFFFFFF38))); LLIL_STORE.128(LLIL_REG.q(x12),LLIL_REG.128(q11))'), # str q11, [x12, #-200]!
-	(b'\x89\xBC\x80\x3C', 'LLIL_SET_REG.q(x4,LLIL_ADD.q(LLIL_REG.q(x4),LLIL_CONST.q(0xB))); LLIL_STORE.128(LLIL_REG.q(x4),LLIL_REG.128(q9))'), # str q9, [x4, #11]!
+	(b'\x8B\x8D\x93\x3C', 'LLIL_SET_REG.q(x12,LLIL_ADD.q(LLIL_REG.q(x12),LLIL_CONST.q(0xFFFFFFFFFFFFFF38))); LLIL_STORE.o(LLIL_REG.q(x12),LLIL_REG.o(q11))'), # str q11, [x12, #-200]!
+	(b'\x89\xBC\x80\x3C', 'LLIL_SET_REG.q(x4,LLIL_ADD.q(LLIL_REG.q(x4),LLIL_CONST.q(0xB))); LLIL_STORE.o(LLIL_REG.q(x4),LLIL_REG.o(q9))'), # str q9, [x4, #11]!
 	# IFORM: STR_imm_fpsimd (class unsigned_scaled_offset)
 	# STR_B_ldst_pos 0011110100xxxxxxxxxxxxxxxxxxxxxx
 	(b'\x0B\xB2\x30\x3D', 'LLIL_STORE.b(LLIL_ADD.q(LLIL_REG.q(x16),LLIL_CONST.q(0xC2C)),LLIL_REG.b(b11))'), # str b11, [x16, #3116]
@@ -246,8 +246,8 @@ test_cases = [
 	(b'\xF0\xC8\x34\xFD', 'LLIL_STORE.q(LLIL_ADD.q(LLIL_REG.q(x7),LLIL_CONST.q(0x6990)),LLIL_REG.q(d16))'), # str d16, [x7, #27024]
 	(b'\xBF\x6F\x17\xFD', 'LLIL_STORE.q(LLIL_ADD.q(LLIL_REG.q(x29),LLIL_CONST.q(0x2ED8)),LLIL_REG.q(d31))'), # str d31, [x29, #11992]
 	# STR_Q_ldst_pos 0011110110xxxxxxxxxxxxxxxxxxxxxx
-	(b'\x70\x26\x93\x3D', 'LLIL_STORE.128(LLIL_ADD.q(LLIL_REG.q(x19),LLIL_CONST.q(0x4C90)),LLIL_REG.128(q16))'), # str q16, [x19, #19600]
-	(b'\xE8\xB0\x88\x3D', 'LLIL_STORE.128(LLIL_ADD.q(LLIL_REG.q(x7),LLIL_CONST.q(0x22C0)),LLIL_REG.128(q8))'), # str q8, [x7, #8896]
+	(b'\x70\x26\x93\x3D', 'LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x19),LLIL_CONST.q(0x4C90)),LLIL_REG.o(q16))'), # str q16, [x19, #19600]
+	(b'\xE8\xB0\x88\x3D', 'LLIL_STORE.o(LLIL_ADD.q(LLIL_REG.q(x7),LLIL_CONST.q(0x22C0)),LLIL_REG.o(q8))'), # str q8, [x7, #8896]
 	# IFORM: str_p_bi
 	# str_p_bi_ 1110010110xxxxxx000xxxxxxxx0xxxx
 	#(b'\xA6\x12\xB0\xE5', 'LLIL_UNDEF()'), # str p6, [x21, #-124, mul vl]
@@ -319,7 +319,7 @@ test_cases = [
 	(b'\x52\x26\x73\xF8', 'LLIL_SET_REG.q(x18,LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x18),LLIL_CONST.q(0xFFFFFFFFFFFFF990))))'), # ldraa x18, [x18, #-1648]
 	# LDRAB_64W_ldst_pac 111110001x1xxxxxxxxx11xxxxxxxxxx
 	(b'\x68\xDE\xB8\xF8', 'LLIL_SET_REG.q(x19,LLIL_ADD.q(LLIL_REG.q(x19),LLIL_CONST.q(0xC68))); LLIL_SET_REG.q(x8,LLIL_LOAD.q(LLIL_REG.q(x19)))'), # ldrab x8, [x19, #3176]!
-	(b'\x8D\x0D\xFF\xF8', 'LLIL_SET_REG.q(x12,LLIL_ADD.q(LLIL_REG.q(x12),LLIL_CONST.q(0xFFFFFFFFFFFFFF80))); LLIL_SET_REG.q(x13,LLIL_LOAD.q(LLIL_REG.q(x12)))'), # ldrab x13, [x12, #-128]!
+	(b'\x8D\x0D\xFF\xF8', 'LLIL_SET_REG.q(x12,LLIL_ADD.q(LLIL_REG.q(x12),LLIL_CONST.q(0xFFFFFFFFFFFFFF80))); LLIL_SET_REG.q(x13,LLIL_LOAD.q(LLIL_REG.q(x12)))'), # ldrab x13, [x12, #-o]!
 	# LDRAB_64_ldst_pac 111110001x1xxxxxxxxxxxxxxxxxxxxx
 	(b'\x94\xF5\xA1\xF8', 'LLIL_SET_REG.q(x20,LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x12),LLIL_CONST.q(0xF8))))'), # ldrab x20, [x12, #248]
 	(b'\x2B\x35\xAA\xF8', 'LLIL_SET_REG.q(x11,LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x9),LLIL_CONST.q(0x518))))'), # ldrab x11, [x9, #1304]
@@ -460,8 +460,8 @@ test_cases = [
 	(b'\x21\xf0\x9f\xf8', 'LLIL_INTRINSIC([],__prefetch,LLIL_CALL_PARAM([LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x1),LLIL_CONST.q(0xFFFFFFFFFFFFFFFF)))]))'), # prfum pldl1strm, [x1, #-0x1]
 	(b'\x21\x00\x80\xf9', 'LLIL_INTRINSIC([],__prefetch,LLIL_CALL_PARAM([LLIL_LOAD.q(LLIL_REG.q(x1))]))'), # prfm pldl1strm, [x1]
 	(b'\x24\x98\x41\xba', 'LLIL_IF(LLIL_OR(LLIL_FLAG(z),LLIL_FLAG(c)),1,3); LLIL_ADD.q(LLIL_REG.q(x1),LLIL_CONST.q(0x1)); LLIL_GOTO(8); LLIL_SET_FLAG(n,LLIL_CONST(0)); LLIL_SET_FLAG(z,LLIL_CONST(1)); LLIL_SET_FLAG(c,LLIL_CONST(0)); LLIL_SET_FLAG(v,LLIL_CONST(0)); LLIL_GOTO(8)'), # ccmn x1, #0x1, #0x4, ls
-	(b'\x41\x7c\xc3\x9b', 'LLIL_SET_REG.q(x1,LLIL_LSR.128(LLIL_MULU_DP.q(LLIL_REG.q(x2),LLIL_REG.q(x3)),LLIL_CONST.b(0x8)))'), # umulh x1, x2, x3
-	(b'\x41\x7c\x43\x9b', 'LLIL_SET_REG.q(x1,LLIL_LSR.128(LLIL_MULS_DP.q(LLIL_REG.q(x2),LLIL_REG.q(x3)),LLIL_CONST.b(0x8)))'), # smulh x1, x2, x3
+	(b'\x41\x7c\xc3\x9b', 'LLIL_SET_REG.q(x1,LLIL_LSR.o(LLIL_MULU_DP.q(LLIL_REG.q(x2),LLIL_REG.q(x3)),LLIL_CONST.b(0x8)))'), # umulh x1, x2, x3
+	(b'\x41\x7c\x43\x9b', 'LLIL_SET_REG.q(x1,LLIL_LSR.o(LLIL_MULS_DP.q(LLIL_REG.q(x2),LLIL_REG.q(x3)),LLIL_CONST.b(0x8)))'), # smulh x1, x2, x3
 	(b'\x41\x7c\x23\x9b', 'LLIL_SET_REG.q(x1,LLIL_MULS_DP.q(LLIL_REG.d(w2),LLIL_REG.d(w3)))'), # smull x1, w2, w3
 	(b'\x41\x7c\xa3\x9b', 'LLIL_SET_REG.q(x1,LLIL_MULU_DP.q(LLIL_REG.d(w2),LLIL_REG.d(w3)))'), # umull x1, w2, w3
 	(b'\x41\x00\x03\x8b', 'LLIL_SET_REG.q(x1,LLIL_ADD.q(LLIL_REG.q(x2),LLIL_REG.q(x3)))'), # add x1,x2,x3
@@ -517,7 +517,7 @@ from binaryninja import lowlevelil
 from binaryninja.enums import LowLevelILOperation
 
 def il2str(il):
-	sz_lookup = {1:'.b', 2:'.w', 4:'.d', 8:'.q', 16:'.128'}
+	sz_lookup = {1:'.b', 2:'.w', 4:'.d', 8:'.q', 16:'.o'}
 	if isinstance(il, lowlevelil.LowLevelILInstruction):
 		size_suffix = sz_lookup.get(il.size, '?') if il.size else ''
 		# print size-specified IL constants in hex

--- a/arm64test.py
+++ b/arm64test.py
@@ -3,6 +3,10 @@
 RET = b'\xc0\x03\x5f\xd6'
 
 test_cases = [
+	(b'\x00\x70\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b}, [x0]
+	(b'\x00\xa0\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v1,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b}, [x0]
+	(b'\x00\x60\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v1,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v2,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b}, [x0]
+	(b'\x00\x20\x40\x4c', 'LLIL_SET_REG.128(v0,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v1,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v2,LLIL_LOAD.128(LLIL_REG.q(x0))); LLIL_SET_REG.128(v3,LLIL_LOAD.128(LLIL_REG.q(x0)))'), # ld1 {v0.16b, v1.16b, v2.16b, v3.16b}, [x0]
 	(b'\x63\x86\xa3\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_REG.q(x1),LLIL_MULU_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # umsubl  x3, w19, w3, x1
 	(b'\x63\xfe\xa3\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_CONST.q(0x0),LLIL_MULU_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # umnegl  x3, w19, w3
 	(b'\x63\x86\x23\x9b', 'LLIL_SET_REG.q(x3,LLIL_SUB.q(LLIL_REG.q(x1),LLIL_MULS_DP.q(LLIL_REG.d(w19),LLIL_REG.d(w3))))'), # smsubl  x3, w19, w3, x1

--- a/il.cpp
+++ b/il.cpp
@@ -1229,11 +1229,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		LoadStoreOperandSize(il, true, false, 2, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_LDP:
-		//No support for SIMD
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandPair(il, true, instr.operands[0], instr.operands[1], instr.operands[2]);
+		LoadStoreOperandPair(il, true, instr.operands[0], instr.operands[1], instr.operands[2]);
 		break;
 	case ARM64_LDR:
 	case ARM64_LDUR:
@@ -1243,38 +1239,23 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		break;
 	case ARM64_LDRB:
 	case ARM64_LDURB:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, true, false, 1, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, true, false, 1, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_LDRH:
 	case ARM64_LDURH:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, true, false, 2, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, true, false, 2, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_LDRSB:
 	case ARM64_LDURSB:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, true, true, 1, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, true, true, 1, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_LDRSH:
 	case ARM64_LDURSH:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, true, true, 2, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, true, true, 2, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_LDRSW:
 	case ARM64_LDURSW:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, true, true, 4, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, true, true, 4, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_LD1:
 		{
@@ -1543,10 +1524,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		il.AddInstruction(il.Intrinsic({}, ARM64_INTRIN_SEVL, {}));
 		break;
 	case ARM64_STP:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandPair(il, false, instr.operands[0], instr.operands[1], instr.operands[2]);
+		LoadStoreOperandPair(il, false, instr.operands[0], instr.operands[1], instr.operands[2]);
 		break;
 	case ARM64_STR:
 	case ARM64_STUR:
@@ -1554,17 +1532,11 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		break;
 	case ARM64_STRB:
 	case ARM64_STURB:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, false, false, 1, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, false, false, 1, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_STRH:
 	case ARM64_STURH:
-		if (instr.operands[0].reg[0] >= REG_B0 && instr.operands[0].reg[0] <= REG_Q31)
-			il.AddInstruction(il.Unimplemented());
-		else
-			LoadStoreOperandSize(il, false, false, 2, instr.operands[0], instr.operands[1]);
+		LoadStoreOperandSize(il, false, false, 2, instr.operands[0], instr.operands[1]);
 		break;
 	case ARM64_SUB:
 	case ARM64_SUBS:


### PR DESCRIPTION
Also update the tests to use `.o` as a size suffix to match the rest of them.

I _think_ the prefix/postfix memory operations are correct, but a second set of eyes would be really appreciated there.