### PR TITLE
Fix MSVC build

### DIFF
--- a/neon_intrinsics.h
+++ b/neon_intrinsics.h
@@ -2,13 +2,13 @@
 
 #include <vector>
 #include <string>
-using namespace std;
 
 // from api
 #include "lowlevelilinstruction.h"
-using namespace BinaryNinja;
-
 #include "il.h" /* for ARM64_INTRIN_NORMAL_END, ExtractRegister() */
+
+using namespace std;
+using namespace BinaryNinja;
 
 enum NeonIntrinsic : uint32_t
 {


### PR DESCRIPTION
I shoud have actually mentioned what the problem was in the last commit
-- if you include files after using the std namespace, there is a
conflict from some windows header with std::byte.

Thankfully simply reordering them is enough to fix it.

Example error:
```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um\oaidl.h(563,26): error C2872: 'byte': ambiguous symbol [C:\Users\x\Documents\binja\arch-arm64\build\arch_arm64.vcxproj]
```