### PR TITLE
Fix mov lift when a vector lane is used

### DIFF
--- a/arm64test.py
+++ b/arm64test.py
@@ -418,7 +418,9 @@ tests_stnp = [
 
 tests_mov = [
 	# 011c044e   mov     v1.s[0], w0
-	(b'\x01\x1c\x04\x4e', 'LLIL_SET_REG.d(v1.s[0],LLIL_ZX.o(LLIL_REG.d(w0)))'),
+	(b'\x01\x1c\x04\x4e', 'LLIL_SET_REG.d(v1.s[0],LLIL_REG.d(w0))'),
+	# mov w10, #0
+	(b'\x0a\x00\x80\x52', 'LLIL_SET_REG.d(w10,LLIL_CONST.d(0x0))'),
 ]
 
 tests_movi = [
@@ -1928,7 +1930,6 @@ test_cases = \
 	(b'\x22\x6A\x41\x7A', 'LLIL_IF(LLIL_FLAG(v),1,3); LLIL_SUB.d(LLIL_REG.d(w17),LLIL_CONST.d(0x1)); LLIL_GOTO(8); LLIL_SET_FLAG(n,LLIL_CONST(0)); LLIL_SET_FLAG(z,LLIL_CONST(0)); LLIL_SET_FLAG(c,LLIL_CONST(1)); LLIL_SET_FLAG(v,LLIL_CONST(0)); LLIL_GOTO(8)'), # ccmp w17, #1, #2, vs
 	(b'\xA8\xA8\x41\x7A', 'LLIL_IF(LLIL_CMP_E(LLIL_FLAG(n),LLIL_FLAG(v)),1,3); LLIL_SUB.d(LLIL_REG.d(w5),LLIL_CONST.d(0x1)); LLIL_GOTO(8); LLIL_SET_FLAG(n,LLIL_CONST(1)); LLIL_SET_FLAG(z,LLIL_CONST(0)); LLIL_SET_FLAG(c,LLIL_CONST(0)); LLIL_SET_FLAG(v,LLIL_CONST(0)); LLIL_GOTO(8)'), # ccmp w5, #1, #8, ge
 	(b'\x08\x49\x5E\x7A', 'LLIL_IF(LLIL_FLAG(n),1,3); LLIL_SUB.d(LLIL_REG.d(w8),LLIL_CONST.d(0x1E)); LLIL_GOTO(8); LLIL_SET_FLAG(n,LLIL_CONST(1)); LLIL_SET_FLAG(z,LLIL_CONST(0)); LLIL_SET_FLAG(c,LLIL_CONST(0)); LLIL_SET_FLAG(v,LLIL_CONST(0)); LLIL_GOTO(8)'), # ccmp w8, #30, #8, mi
-	(b'\x0a\x00\x80\x52', 'LLIL_SET_REG.d(w10,LLIL_CONST.d(0x0))'), # mov 10, #0
 	(b'\x1f\x20\x03\xd5', ''), # nop, gets optimized from function
 ]
 

--- a/arm64test.py
+++ b/arm64test.py
@@ -416,6 +416,11 @@ tests_stnp = [
 						 ' LLIL_STORE.d(LLIL_ADD.q(LLIL_REG.q(x17),LLIL_CONST.q(0x30)),LLIL_REG.d(s6))'),
 ]
 
+tests_mov = [
+	# 011c044e   mov     v1.s[0], w0
+	(b'\x01\x1c\x04\x4e', 'LLIL_SET_REG.d(v1.s[0],LLIL_ZX.o(LLIL_REG.d(w0)))'),
+]
+
 tests_movi = [
 	# movi v4.2d, #0xffffff0000ffff                                    MOVI_ASIMDIMM_D2_D
 	(b'\x64\xE6\x03\x6F', 'LLIL_SET_REG.q(v4.d[0],LLIL_CONST.q(0xFFFFFF0000FFFF));' + \
@@ -1344,6 +1349,7 @@ test_cases = \
 	tests_stlr + \
 	tests_ldnp + \
 	tests_stnp + \
+	tests_mov + \
 	tests_movi + \
 	tests_fsub + \
 	tests_fadd + \

--- a/il.cpp
+++ b/il.cpp
@@ -1616,7 +1616,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		int n = unpack_vector(operand1, regs);
 
 		if (n == 1)
-			il.AddInstruction(ILSETREG(regs[0], ReadILOperand(il, instr.operands[1], REGSZ_O(operand1))));
+			il.AddInstruction(ILSETREG(regs[0], ReadILOperand(il, operand2, get_register_size(regs[0]))));
 		else
 			ABORT_LIFT;
 


### PR DESCRIPTION
Previously `mov v1.s[0], w0` would ignore the lane and be lifted as `mov
v1, w0`. This updates the vector unpack code to handle the single
register lane case, and updates the ARM64_MOV lift to use it.