### PR TITLE
Tidy register functions

### DIFF
--- a/disassembler/decode.c
+++ b/disassembler/decode.c
@@ -3,30 +3,6 @@
 int decode_spec(context *ctx, Instruction *dec); // from decode0.cpp
 int decode_scratchpad(context *ctx, Instruction *dec); // from decode_scratchpad.c
 
-size_t get_register_size(Register r)
-{
-	//Comparison done in order of likelyhood to occur
-	if ((r >= REG_X0 && r <= REG_SP) || (r >= REG_D0 && r <= REG_D31))
-		return 8;
-	else if ((r >= REG_W0 && r <= REG_WSP) || (r >= REG_S0 && r <= REG_S31))
-		return 4;
-	else if (r >= REG_B0 && r <= REG_B31)
-		return 1;
-	else if (r >= REG_H0 && r <= REG_H31)
-		return 2;
-	else if ((r >= REG_Q0 && r <= REG_Q31) || (r >= REG_V0 && r <= REG_V31))
-		return 16;
-	else if (r >= REG_V0_B0 && r <= REG_V31_B15)
-		return 1;
-	else if (r >= REG_V0_H0 && r <= REG_V31_H7)
-		return 2;
-	else if (r >= REG_V0_S0 && r <= REG_V31_S3)
-		return 4;
-	else if (r >= REG_V0_D0 && r <= REG_V31_D1)
-		return 8;
-	return 0;
-}
-
 int aarch64_decompose(uint32_t instructionValue, Instruction *instr, uint64_t address)
 {
 	context ctx = { 0 };

--- a/disassembler/regs.c
+++ b/disassembler/regs.c
@@ -192,3 +192,27 @@ const char *get_register_name(enum Register r)
 
 	return "";
 }
+
+size_t get_register_size(enum Register r)
+{
+	//Comparison done in order of likelyhood to occur
+	if ((r >= REG_X0 && r <= REG_SP) || (r >= REG_D0 && r <= REG_D31))
+		return 8;
+	else if ((r >= REG_W0 && r <= REG_WSP) || (r >= REG_S0 && r <= REG_S31))
+		return 4;
+	else if (r >= REG_B0 && r <= REG_B31)
+		return 1;
+	else if (r >= REG_H0 && r <= REG_H31)
+		return 2;
+	else if ((r >= REG_Q0 && r <= REG_Q31) || (r >= REG_V0 && r <= REG_V31))
+		return 16;
+	else if (r >= REG_V0_B0 && r <= REG_V31_B15)
+		return 1;
+	else if (r >= REG_V0_H0 && r <= REG_V31_H7)
+		return 2;
+	else if (r >= REG_V0_S0 && r <= REG_V31_S3)
+		return 4;
+	else if (r >= REG_V0_D0 && r <= REG_V31_D1)
+		return 8;
+	return 0;
+}

--- a/disassembler/regs.h
+++ b/disassembler/regs.h
@@ -189,6 +189,7 @@ enum Register {
 extern "C" {
 #endif
 const char *get_register_name(enum Register);
+size_t get_register_size(enum Register);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When I split out regs I missed this function. Oops.