### PR TITLE
Enable support for big-endian ARM64

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -2916,7 +2916,9 @@ extern "C"
 		// these architectures for disassembling an executable file
 		BinaryViewType::RegisterArchitecture("Mach-O", 0x0100000c, LittleEndian, arm64);
 		BinaryViewType::RegisterArchitecture("ELF", 0xb7, LittleEndian, arm64);
+		BinaryViewType::RegisterArchitecture("ELF", 0xb7, BigEndian, arm64);
 		BinaryViewType::RegisterArchitecture("PE", 0xaa64, LittleEndian, arm64);
+		BinaryViewType::RegisterArchitecture("PE", 0xaa64, BigEndian, arm64);
 		arm64->SetBinaryViewTypeConstant("ELF", "R_COPY", 0x400);
 		arm64->SetBinaryViewTypeConstant("ELF", "R_JUMP_SLOT", 0x402);
 


### PR DESCRIPTION
This appears to work so far? I assume it's just that no one had ever seen a big-endian ARM64 before, which is fair.