### PR TITLE
add register consolidation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ if((NOT BN_API_PATH) AND (NOT BN_INTERNAL_BUILD))
 		message(FATAL_ERROR "Provide path to Binary Ninja API source in BN_API_PATH")
 	endif()
 endif()
+
+if((NOT BN_INSTALL_DIR) AND (NOT BN_INTERNAL_BUILD) AND WIN32)
+	set(BN_INSTALL_DIR $ENV{BN_INSTALL_DIR})
+	if(NOT BN_INSTALL_DIR)
+		message(FATAL_ERROR "Provide path to Binary Ninja installation in BN_INSTALL_DIR")
+	endif()
+endif()
+
 if(NOT BN_INTERNAL_BUILD)
 	add_subdirectory(${BN_API_PATH} ${PROJECT_BINARY_DIR}/api)
 endif()
@@ -47,19 +55,27 @@ target_include_directories(arch_arm64
 
 target_link_libraries(arch_arm64 binaryninjaapi)
 
+if(WIN32)
+	target_link_directories(arch_arm64
+		PRIVATE ${BN_INSTALL_DIR})
+	target_link_libraries(arch_arm64 binaryninjaapi binaryninjacore)
+else()
+	target_link_libraries(arch_arm64 binaryninjaapi)
+endif()
+
 set_target_properties(arch_arm64 PROPERTIES
-    CXX_STANDARD 17
+	CXX_STANDARD 17
 	CXX_VISIBILITY_PRESET hidden
 	CXX_STANDARD_REQUIRED ON
 	C_STANDARD 99
 	C_STANDARD_REQUIRED ON
-    C_VISIBILITY_PRESET hidden
-    VISIBILITY_INLINES_HIDDEN ON
+	C_VISIBILITY_PRESET hidden
+	VISIBILITY_INLINES_HIDDEN ON
 	POSITION_INDEPENDENT_CODE ON)
 
 if(BN_INTERNAL_BUILD)
 	plugin_rpath(arch_arm64)
 	set_target_properties(arch_arm64 PROPERTIES
-		LIBRARY_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR}
-		RUNTIME_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR})
+	LIBRARY_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR}
+	RUNTIME_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR})
 endif()

--- a/arm64test.py
+++ b/arm64test.py
@@ -551,6 +551,10 @@ tests_mov = [
 	(b'\x01\x1C\x04\x4E', 'LLIL_SET_REG.d(v1.s[0],LLIL_REG.d(w0))'),
 	# mov w10, #0
 	(b'\x0A\x00\x80\x52', 'LLIL_SET_REG.d(w10,LLIL_CONST.d(0x0))'),
+	# mov v8.16b, v1.16b
+	(b'\x28\x1c\xa1\x4e', 'LLIL_SET_REG.o(v8,LLIL_REG.o(v1))'),
+	# mov v0.2s, v1.2s
+	(b'\x20\x1c\xa1\x0e', 'LLIL_SET_REG.q(v0.d[0],LLIL_REG.q(v1.d[0]))'),
 ]
 
 tests_movi = [

--- a/il.cpp
+++ b/il.cpp
@@ -554,6 +554,29 @@ static int unpack_vector(InstructionOperand& oper, Register *result)
 	return 0;
 }
 
+/* if we have two operands that have the same arrangement spec, instead of treating them as
+    distinct sets of registers, see if we can consolidate the set of registers into a single
+    larger register. This allows us to easily lift things like 'mov v0.16b, v1.16b' as
+    'mov v0, v1' */
+static int consolidate_vector(
+		InstructionOperand& operand1,
+		InstructionOperand& operand2,
+		Register *result)
+{
+	/* make sure both our operand classes are single regs */
+	if (operand1.operandClass != REG || operand2.operandClass != REG)
+		return 0;
+
+	/* make sure our arrSpec's match. We need this to deal with cases where the arrSpec might
+        have different sizes, e.g. 'uxtl v2.2d, v8.2s'.*/
+	if (operand1.arrSpec != operand2.arrSpec)
+		return 0;
+
+	result[0] = v_consolidate_lookup[operand1.reg[0]-REG_V0][operand1.arrSpec];
+	result[1] = v_consolidate_lookup[operand2.reg[0]-REG_V0][operand2.arrSpec];
+
+	return 1;
+}
 
 static void LoadStoreOperandPair(
 		LowLevelILFunction& il,
@@ -1617,10 +1640,15 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		Register regs[16];
 		int n = unpack_vector(operand1, regs);
 
-		if (n == 1)
+		if (n == 1) {
 			il.AddInstruction(ILSETREG(regs[0], ReadILOperand(il, operand2, get_register_size(regs[0]))));
-		else
-			ABORT_LIFT;
+		} else {
+			Register cregs[2];
+			if (consolidate_vector(operand1, operand2, cregs))
+				il.AddInstruction(ILSETREG(cregs[0], ILREG(cregs[1])));
+			else
+				ABORT_LIFT;
+		}
 
 		break;
 	}


### PR DESCRIPTION
Currently vector registers like `v0.16b` are treated as a set of
sixteen, 1byte registers. This presents problem when lifting, because
`mov v0.16b, v1.16b` would need to be lifted as 16 register moves.

This PR introduces register consolidation, essentially lifting a
reference to `v0.16b` as `v0` provided that:
- the source and destination of a mov are both single registers (i.e.
  not `{v0, v1}`)
- the source and destination have the same arrangement spec.

This allows us to lift `mov v0.16b, v1.16b` as `v0 = v1`, or `mov v0.2s,
v1.2s` as `v0.d[0] = v1.d[0]`.