### PR TITLE
remove unneeded and flag lift

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1305,20 +1305,6 @@ class Arm64Architecture : public Architecture
 	{
 		switch (op)
 		{
-		case LLIL_AND:
-			switch (flag)
-			{
-			case IL_FLAG_V:
-				return il.CompareNotEqual(0,
-				    il.Xor(0,
-				        il.CompareSignedLessThan(size,
-				            il.GetExprForRegisterOrConstantOperation(op, size, operands, operandCount),
-				            il.Const(size, 0)),
-				        il.Flag(IL_FLAG_V)),
-				    il.Const(0, 0));
-			case IL_FLAG_C:
-				return il.Const(0, 0);
-			}
 		case LLIL_SBB:
 			switch (flag)
 			{


### PR DESCRIPTION
Tests still pass, verified that this is unneeded by looking at the lifted il for:

```
0004a90c  4500056a   ands    w5, w2, w5
0004a910  01020054   b.ne    0x4a950
```

lifts to:
```
2014 @ 0004a90c  w5 = and.d{*}(w2, w5)
2015 @ 0004a910  if (!=) then 2029 @ 0x4a950 else 2042 @ 0x4a914  { uses flag:z from 2014 @ 0x4a90c }
// flag:v,c,z,n set by 2014 @ 0x4a90c
```

This was originally needed because setflags wasnt set on `ands`, but with the recent bugfix there this code is now useless.