### PR TITLE
use V registers instead of Q

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1369,10 +1369,10 @@ class Arm64Architecture : public Architecture
 			REG_X16,  REG_X17, REG_X18, REG_X19,  REG_X20, REG_X21, REG_X22, REG_X23,
 			REG_X24,  REG_X25, REG_X26, REG_X27,  REG_X28, REG_X29, REG_X30, REG_SP,  REG_XZR,
 			// Vector
-			REG_Q0,   REG_Q1,  REG_Q2,  REG_Q3,   REG_Q4,  REG_Q5,  REG_Q6,  REG_Q7,
-			REG_Q8,   REG_Q9,  REG_Q10, REG_Q11,  REG_Q12, REG_Q13, REG_Q14, REG_Q15,
-			REG_Q16,  REG_Q17, REG_Q18, REG_Q19,  REG_Q20, REG_Q21, REG_Q22, REG_Q23,
-			REG_Q24,  REG_Q25, REG_Q26, REG_Q27,  REG_Q28, REG_Q29, REG_Q30, REG_Q31,
+			REG_V0,   REG_V1,  REG_V2,  REG_V3,   REG_V4,  REG_V5,  REG_V6,  REG_V7,
+			REG_V8,   REG_V9,  REG_V10, REG_V11,  REG_V12, REG_V13, REG_V14, REG_V15,
+			REG_V16,  REG_V17, REG_V18, REG_V19,  REG_V20, REG_V21, REG_V22, REG_V23,
+			REG_V24,  REG_V25, REG_V26, REG_V27,  REG_V28, REG_V29, REG_V30, REG_V31,
 			// SVE
 			REG_P0,   REG_P1,  REG_P2,  REG_P3,   REG_P4,  REG_P5,  REG_P6,  REG_P7,
 			REG_P8,   REG_P9,  REG_P10,  REG_P11,   REG_P12,  REG_P13,  REG_P14,  REG_P15,
@@ -2402,7 +2402,7 @@ class Arm64CallingConvention : public CallingConvention
 
 	virtual vector<uint32_t> GetFloatArgumentRegisters() override
 	{
-		return vector<uint32_t> {REG_Q0, REG_Q1, REG_Q2, REG_Q3, REG_Q4, REG_Q5, REG_Q6, REG_Q7};
+		return vector<uint32_t> {REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7};
 	}
 
 
@@ -2410,9 +2410,9 @@ class Arm64CallingConvention : public CallingConvention
 	{
 		return vector<uint32_t> {REG_X0, REG_X1, REG_X2, REG_X3, REG_X4, REG_X5, REG_X6, REG_X7, REG_X8,
 		    REG_X9, REG_X10, REG_X11, REG_X12, REG_X13, REG_X14, REG_X15, REG_X16, REG_X17, REG_X18,
-		    REG_X30, REG_Q0, REG_Q1, REG_Q2, REG_Q3, REG_Q4, REG_Q5, REG_Q6, REG_Q7, REG_Q16, REG_Q17,
-		    REG_Q18, REG_Q19, REG_Q20, REG_Q21, REG_Q22, REG_Q23, REG_Q24, REG_Q25, REG_Q26, REG_Q27,
-		    REG_Q28, REG_Q29, REG_Q30, REG_Q31};
+		    REG_X30, REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7, REG_V16, REG_V17,
+		    REG_V18, REG_V19, REG_V20, REG_V21, REG_V22, REG_V23, REG_V24, REG_V25, REG_V26, REG_V27,
+		    REG_V28, REG_V29, REG_V30, REG_V31};
 	}
 
 
@@ -2426,7 +2426,7 @@ class Arm64CallingConvention : public CallingConvention
 	virtual uint32_t GetIntegerReturnValueRegister() override { return REG_X0; }
 
 
-	virtual uint32_t GetFloatReturnValueRegister() override { return REG_Q0; }
+	virtual uint32_t GetFloatReturnValueRegister() override { return REG_V0; }
 };
 
 


### PR DESCRIPTION
As part of the vector register refactor we made the V registers the
"base" register, which are windowed into by the b, h, s, and q
registers. However, the calling convention was not updated to switch
from q to v registers, nor were the full width registers changed. The
v and q registers are 1:1 aliases of each other, both 16 bytes.

Currently, the situation is kind of weird: the Q registers are defined
as the full width registers, however are implemented in terms of a view
into the V registers. This is probably a bug, even though it mostly
works -- I think (?) the API expects that you'll always window into the
full width regsters. The fix for this is easy as theyre both the same
width -- we just make the V regsiters the full width regsiters.

Next, we just update the calling convetion to use the V registers
instead of their Q counterparts. This is partially due to calling
conventions inability to use subregisters (even though V and Q are the
same size, Q still isnt a full width register...), see
https://github.com/Vector35/binaryninja-api/issues/2793. However, even
aside from this issue, this appears to be more accurate:
- https://developer.arm.com/documentation/den0024/a/The-ABI-for-ARM-64-bit-Architecture/Register-use-in-the-AArch64-Procedure-Call-Standard/Parameters-in-NEON-and-floating-point-registers
- https://docs.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170
- https://en.wikipedia.org/wiki/Calling_convention#ARM_(A64)

With this change applied, functions that take floating point paramters
are cleaned up, e.g. `atan` goes from `void atan(double arg1 @ v0)` to
`void atan(double arg1)`.