### PR TITLE
fix movk

### DIFF
--- a/arm64test.py
+++ b/arm64test.py
@@ -2,6 +2,10 @@
 
 RET = b'\xc0\x03\x5f\xd6'
 
+tests_movk = [
+    (b'\xe9\xae\xb7\xf2', 'LLIL_SET_REG.q(x9,LLIL_AND.q(LLIL_REG.q(x9),LLIL_NOT.q(LLIL_CONST.q(0xFFFF0000)))); LLIL_SET_REG.q(x9,LLIL_OR.q(LLIL_REG.q(x9),LLIL_CONST.q(0xBD770000)))'), # movk    x9, #0xbd77, lsl #0x10
+]
+
 tests_mvni = [
     (b'\xe2\x05\x01\x6f', 'LLIL_SET_REG.o(v2,LLIL_NOT.o(LLIL_CONST.o(0x2F)))'), # mvni    v2.4s, #0x2f
 ]
@@ -1502,6 +1506,7 @@ tests_st1 = [
 ]
 
 test_cases = \
+	tests_movk + \
 	tests_mvni + \
 	tests_2791 + \
 	tests_ucvtf + \

--- a/il.cpp
+++ b/il.cpp
@@ -1743,6 +1743,12 @@ bool GetLowLevelILForInstruction(
 		    operand1, il.Not(REGSZ_O(operand1), ReadILOperand(il, operand2, REGSZ_O(operand1)))));
 		break;
 	case ARM64_MOVK:
+		// zero the underling register slice
+		il.AddInstruction(ILSETREG_O(
+		    operand1, il.And(REGSZ_O(operand1), ILREG_O(operand1),
+			il.Not(REGSZ_O(operand1),
+			    il.Const(REGSZ_O(operand1), 0xffffULL << operand2.shiftValue)))));
+		// mov the immediate into it
 		il.AddInstruction(ILSETREG_O(
 		    operand1, il.Or(REGSZ_O(operand1), ILREG_O(operand1),
 		                  il.Const(REGSZ_O(operand1), IMM_O(operand2) << operand2.shiftValue))));


### PR DESCRIPTION
movk overwrites a 16bit slice of a register with an immediate from the
instruction. The current lift assumes the existing bits are zero and
just ORs in the new bits. This is incorrect and results in dataflow
inaccuracies.

Theoretically we could introduce even more register windows to handle
this instead of masking but ehhhhhhhhh....

Reported by @ek0