### PR TITLE
implement label lifting for LoadStoreOperandSize

### DIFF
--- a/arm64test.py
+++ b/arm64test.py
@@ -1995,6 +1995,7 @@ test_cases = \
 	# LDRAB_64_ldst_pac 111110001x1xxxxxxxxxxxxxxxxxxxxx
 	(b'\x94\xF5\xA1\xF8', 'LLIL_SET_REG.q(x20,LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x12),LLIL_CONST.q(0xF8))))'), # ldrab x20, [x12, #248]
 	(b'\x2B\x35\xAA\xF8', 'LLIL_SET_REG.q(x11,LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x9),LLIL_CONST.q(0x518))))'), # ldrab x11, [x9, #1304]
+	(b'\x28\x1b\x02\x90', 'LLIL_SET_REG.q(x8,LLIL_CONST.q(0x4364000))'), # ldrsw   x8, 0x100008000
 	# PACDA_64P_dp_1src 1101101011000001000010xxxxxxxxxx
 	(b'\xAC\x0B\xC1\xDA', 'LLIL_INTRINSIC([x12],__pacda,LLIL_CALL_PARAM([LLIL_REG.q(x29)]))'), # pacda x12, x29
 	(b'\xD2\x09\xC1\xDA', 'LLIL_INTRINSIC([x18],__pacda,LLIL_CALL_PARAM([LLIL_REG.q(x14)]))'), # pacda x18, x14

--- a/il.cpp
+++ b/il.cpp
@@ -925,6 +925,10 @@ static void LoadStoreOperandSize(LowLevelILFunction& il, bool load, bool signedI
 
 			il.AddInstruction(ILSETREG_O(operand1, tmp));
 			break;
+		case LABEL:
+			il.AddInstruction(ILSETREG_O(
+			    operand1, il.Operand(1, il.Load(size, il.ConstPointer(8, IMM_O(operand2))))));
+			break;
 		default:
 			il.AddInstruction(il.Unimplemented());
 			break;


### PR DESCRIPTION
Fixes missing ldrsw lift from binary in https://github.com/Vector35/binaryninja-api/issues/2914

Lift itself is just coped from LoadStoreOperand.