### PR TITLE
Fix lifting of PAC intrinsics

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -1030,29 +1030,29 @@ class Arm64Architecture : public Architecture
 	{
 		switch (intrinsic)
 		{
-		case ARM64_INTRIN_AUTDA:      // reads <Xn|SP>
-		case ARM64_INTRIN_AUTDB:      // reads <Xn|SP>
-		case ARM64_INTRIN_AUTIA:      // reads <Xn|SP>
-		case ARM64_INTRIN_AUTIB:      // reads <Xn|SP>
-		case ARM64_INTRIN_AUTIB1716:  // reads x16
 		case ARM64_INTRIN_CLZ:        // reads <Xn>
 		case ARM64_INTRIN_DC:         // reads <Xt>
 		case ARM64_INTRIN_MSR:
 		case ARM64_INTRIN_MRS:
-		case ARM64_INTRIN_PACDA:      // reads <Xn>
-		case ARM64_INTRIN_PACDB:      // reads <Xn>
-		case ARM64_INTRIN_PACIA:      // reads <Xn>
-		case ARM64_INTRIN_PACIA1716:  // reads x16
-		case ARM64_INTRIN_PACIB:      // reads <Xn>
-		case ARM64_INTRIN_PACIB1716:  // reads x16
 		case ARM64_INTRIN_PRFM:
 		case ARM64_INTRIN_REV:   // reads <Xn>
 		case ARM64_INTRIN_RBIT:  // reads <Xn>
 			return {NameAndType(Type::IntegerType(8, false))};
-		case ARM64_INTRIN_AUTIBSP:  // reads x30, sp
-		case ARM64_INTRIN_PACGA:    // reads <Xn>, <Xm|SP>
-		case ARM64_INTRIN_PACIASP:  // reads x30, sp
-		case ARM64_INTRIN_PACIBSP:  // reads x30, sp
+		case ARM64_INTRIN_AUTDA:      // reads <Xd>, <Xn|SP>
+		case ARM64_INTRIN_AUTDB:      // reads <Xd>, <Xn|SP>
+		case ARM64_INTRIN_AUTIA:      // reads <Xd>, <Xn|SP>
+		case ARM64_INTRIN_AUTIB:      // reads <Xd>, <Xn|SP>
+		case ARM64_INTRIN_AUTIB1716:  // reads x17, x16
+		case ARM64_INTRIN_AUTIBSP:    // reads x30, sp
+		case ARM64_INTRIN_PACGA:      // reads <Xn>, <Xm|SP>
+		case ARM64_INTRIN_PACIASP:    // reads x30, sp
+		case ARM64_INTRIN_PACIBSP:    // reads x30, sp
+		case ARM64_INTRIN_PACDA:      // reads <Xd>, <Xn>
+		case ARM64_INTRIN_PACDB:      // reads <Xd>, <Xn>
+		case ARM64_INTRIN_PACIA:      // reads <Xd>, <Xn>
+		case ARM64_INTRIN_PACIA1716:  // reads x17, x16
+		case ARM64_INTRIN_PACIB:      // reads <Xd>, <Xn>
+		case ARM64_INTRIN_PACIB1716:  // reads x17, x16
 			return {NameAndType(Type::IntegerType(8, false)), NameAndType(Type::IntegerType(8, false))};
 		case ARM64_INTRIN_AESD:
 		case ARM64_INTRIN_AESE:

--- a/arm64test.py
+++ b/arm64test.py
@@ -1931,35 +1931,35 @@ test_cases = \
 	#(b'\x4E\x43\x9B\xE5', 'LLIL_UNDEF()'), # str z14, [x26, #216, mul vl]
 	# pointer auth instructions
 	# AUTDA_64P_dp_1src 1101101011000001000110xxxxxxxxxx
-	(b'\x04\x18\xC1\xDA', 'LLIL_INTRINSIC([x4],__autda,LLIL_CALL_PARAM([LLIL_REG.q(x0)]))'), # autda x4, x0
-	(b'\xF4\x18\xC1\xDA', 'LLIL_INTRINSIC([x20],__autda,LLIL_CALL_PARAM([LLIL_REG.q(x7)]))'), # autda x20, x7
+	(b'\x04\x18\xC1\xDA', 'LLIL_INTRINSIC([x4],__autda,LLIL_CALL_PARAM([LLIL_REG.q(x4),LLIL_REG.q(x0)]))'), # autda x4, x0
+	(b'\xF4\x18\xC1\xDA', 'LLIL_INTRINSIC([x20],__autda,LLIL_CALL_PARAM([LLIL_REG.q(x20),LLIL_REG.q(x7)]))'), # autda x20, x7
 	# AUTDB_64P_dp_1src 110110101100000100xxxxxxxxxxxxxx
-	(b'\x94\x1C\xC1\xDA', 'LLIL_INTRINSIC([x20],__autdb,LLIL_CALL_PARAM([LLIL_REG.q(x4)]))'), # autdb x20, x4
-	(b'\xCB\x1E\xC1\xDA', 'LLIL_INTRINSIC([x11],__autdb,LLIL_CALL_PARAM([LLIL_REG.q(x22)]))'), # autdb x11, x22
+	(b'\x94\x1C\xC1\xDA', 'LLIL_INTRINSIC([x20],__autdb,LLIL_CALL_PARAM([LLIL_REG.q(x20),LLIL_REG.q(x4)]))'), # autdb x20, x4
+	(b'\xCB\x1E\xC1\xDA', 'LLIL_INTRINSIC([x11],__autdb,LLIL_CALL_PARAM([LLIL_REG.q(x11),LLIL_REG.q(x22)]))'), # autdb x11, x22
 	# AUTDZA_64Z_dp_1src 110110101100000100111xxxxxxxxxxx
-	(b'\xF3\x3B\xC1\xDA', 'LLIL_INTRINSIC([x19],__autdza,LLIL_CALL_PARAM([]))'), # autdza x19
-	(b'\xF4\x3B\xC1\xDA', 'LLIL_INTRINSIC([x20],__autdza,LLIL_CALL_PARAM([]))'), # autdza x20
+	(b'\xF3\x3B\xC1\xDA', 'LLIL_INTRINSIC([x19],__autdza,LLIL_CALL_PARAM([LLIL_REG.q(x19)]))'), # autdza x19
+	(b'\xF4\x3B\xC1\xDA', 'LLIL_INTRINSIC([x20],__autdza,LLIL_CALL_PARAM([LLIL_REG.q(x20)]))'), # autdza x20
 	# AUTDZB_64Z_dp_1src 11011010110000010xxxxxxxxxxxxxxx
-	(b'\xFE\x3F\xC1\xDA', 'LLIL_INTRINSIC([x30],__autdzb,LLIL_CALL_PARAM([]))'), # autdzb x30
-	(b'\xEE\x3F\xC1\xDA', 'LLIL_INTRINSIC([x14],__autdzb,LLIL_CALL_PARAM([]))'), # autdzb x14
+	(b'\xFE\x3F\xC1\xDA', 'LLIL_INTRINSIC([x30],__autdzb,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # autdzb x30
+	(b'\xEE\x3F\xC1\xDA', 'LLIL_INTRINSIC([x14],__autdzb,LLIL_CALL_PARAM([LLIL_REG.q(x14)]))'), # autdzb x14
 	# AUTIA_64P_dp_1src 1101101011000001000100xxxxxxxxxx
-	(b'\x83\x11\xC1\xDA', 'LLIL_INTRINSIC([x3],__autia,LLIL_CALL_PARAM([LLIL_REG.q(x12)]))'), # autia x3, x12
-	(b'\xD5\x13\xC1\xDA', 'LLIL_INTRINSIC([x21],__autia,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # autia x21, x30
+	(b'\x83\x11\xC1\xDA', 'LLIL_INTRINSIC([x3],__autia,LLIL_CALL_PARAM([LLIL_REG.q(x3),LLIL_REG.q(x12)]))'), # autia x3, x12
+	(b'\xD5\x13\xC1\xDA', 'LLIL_INTRINSIC([x21],__autia,LLIL_CALL_PARAM([LLIL_REG.q(x21),LLIL_REG.q(x30)]))'), # autia x21, x30
 	# AUTIB1716_HI_hints 1101010100000011001000xxxxxxxxxx
-	(b'\xDF\x21\x03\xD5', 'LLIL_INTRINSIC([x17],__autib1716,LLIL_CALL_PARAM([LLIL_REG.q(x16)]))'), # autib1716
+	(b'\xDF\x21\x03\xD5', 'LLIL_INTRINSIC([x17],__autib1716,LLIL_CALL_PARAM([LLIL_REG.q(x17),LLIL_REG.q(x16)]))'), # autib1716
 	# AUTIBSP_HI_hints 110101010000001100100xxxxxxxxxxx
-	(b'\xFF\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__autibsp,LLIL_CALL_PARAM([LLIL_REG.q(sp)]))'), # autibsp
+	(b'\xFF\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__autibsp,LLIL_CALL_PARAM([LLIL_REG.q(x30),LLIL_REG.q(sp)]))'), # autibsp
 	# AUTIBZ_HI_hints 11010101000000110010001111xxxxxx
-	(b'\xDF\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__autibz,LLIL_CALL_PARAM([]))'), # autibz
+	(b'\xDF\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__autibz,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # autibz
 	# AUTIB_64P_dp_1src 1101101011000001000101xxxxxxxxxx
-	(b'\x7C\x16\xC1\xDA', 'LLIL_INTRINSIC([x28],__autib,LLIL_CALL_PARAM([LLIL_REG.q(x19)]))'), # autib x28, x19
-	(b'\xCB\x16\xC1\xDA', 'LLIL_INTRINSIC([x11],__autib,LLIL_CALL_PARAM([LLIL_REG.q(x22)]))'), # autib x11, x22
+	(b'\x7C\x16\xC1\xDA', 'LLIL_INTRINSIC([x28],__autib,LLIL_CALL_PARAM([LLIL_REG.q(x28),LLIL_REG.q(x19)]))'), # autib x28, x19
+	(b'\xCB\x16\xC1\xDA', 'LLIL_INTRINSIC([x11],__autib,LLIL_CALL_PARAM([LLIL_REG.q(x11),LLIL_REG.q(x22)]))'), # autib x11, x22
 	# AUTIZA_64Z_dp_1src 110110101100000100110xxxxxxxxxxx
-	(b'\xEF\x33\xC1\xDA', 'LLIL_INTRINSIC([x15],__autiza,LLIL_CALL_PARAM([]))'), # autiza x15
-	(b'\xF5\x33\xC1\xDA', 'LLIL_INTRINSIC([x21],__autiza,LLIL_CALL_PARAM([]))'), # autiza x21
+	(b'\xEF\x33\xC1\xDA', 'LLIL_INTRINSIC([x15],__autiza,LLIL_CALL_PARAM([LLIL_REG.q(x15)]))'), # autiza x15
+	(b'\xF5\x33\xC1\xDA', 'LLIL_INTRINSIC([x21],__autiza,LLIL_CALL_PARAM([LLIL_REG.q(x21)]))'), # autiz§a x21
 	# AUTIZB_64Z_dp_1src 11011010110000010011xxxxxxxxxxxx
-	(b'\xE4\x37\xC1\xDA', 'LLIL_INTRINSIC([x4],__autizb,LLIL_CALL_PARAM([]))'), # autizb x4
-	(b'\xF4\x37\xC1\xDA', 'LLIL_INTRINSIC([x20],__autizb,LLIL_CALL_PARAM([]))'), # autizb x20
+	(b'\xE4\x37\xC1\xDA', 'LLIL_INTRINSIC([x4],__autizb,LLIL_CALL_PARAM([LLIL_REG.q(x4)]))'), # autizb x4
+	(b'\xF4\x37\xC1\xDA', 'LLIL_INTRINSIC([x20],__autizb,LLIL_CALL_PARAM([LLIL_REG.q(x20)]))'), # autizb x20
 	# BLRAA_64P_branch_reg 1101011100111111000010xxxxxxxxxx
 	(b'\x14\x0B\x3F\xD7', 'LLIL_CALL(LLIL_REG.q(x24))'), # blraa x24, x20
 	(b'\xFD\x0A\x3F\xD7', 'LLIL_CALL(LLIL_REG.q(x23))'), # blraa x23, x29
@@ -2002,58 +2002,58 @@ test_cases = \
 	(b'\x2B\x35\xAA\xF8', 'LLIL_SET_REG.q(x11,LLIL_LOAD.q(LLIL_ADD.q(LLIL_REG.q(x9),LLIL_CONST.q(0x518))))'), # ldrab x11, [x9, #1304]
 	(b'\x28\x1b\x02\x90', 'LLIL_SET_REG.q(x8,LLIL_CONST.q(0x4364000))'), # ldrsw   x8, 0x100008000
 	# PACDA_64P_dp_1src 1101101011000001000010xxxxxxxxxx
-	(b'\xAC\x0B\xC1\xDA', 'LLIL_INTRINSIC([x12],__pacda,LLIL_CALL_PARAM([LLIL_REG.q(x29)]))'), # pacda x12, x29
-	(b'\xD2\x09\xC1\xDA', 'LLIL_INTRINSIC([x18],__pacda,LLIL_CALL_PARAM([LLIL_REG.q(x14)]))'), # pacda x18, x14
+	(b'\xAC\x0B\xC1\xDA', 'LLIL_INTRINSIC([x12],__pacda,LLIL_CALL_PARAM([LLIL_REG.q(x12),LLIL_REG.q(x29)]))'), # pacda x12, x29
+	(b'\xD2\x09\xC1\xDA', 'LLIL_INTRINSIC([x18],__pacda,LLIL_CALL_PARAM([LLIL_REG.q(x18),LLIL_REG.q(x14)]))'), # pacda x18, x14
 	# PACDB_64P_dp_1src 1101101011000001000011xxxxxxxxxx
-	(b'\xF9\x0E\xC1\xDA', 'LLIL_INTRINSIC([x25],__pacdb,LLIL_CALL_PARAM([LLIL_REG.q(x23)]))'), # pacdb x25, x23
-	(b'\xBA\x0C\xC1\xDA', 'LLIL_INTRINSIC([x26],__pacdb,LLIL_CALL_PARAM([LLIL_REG.q(x5)]))'), # pacdb x26, x5
+	(b'\xF9\x0E\xC1\xDA', 'LLIL_INTRINSIC([x25],__pacdb,LLIL_CALL_PARAM([LLIL_REG.q(x25),LLIL_REG.q(x23)]))'), # pacdb x25, x23
+	(b'\xBA\x0C\xC1\xDA', 'LLIL_INTRINSIC([x26],__pacdb,LLIL_CALL_PARAM([LLIL_REG.q(x26),LLIL_REG.q(x5)]))'), # pacdb x26, x5
 	# PACDZA_64Z_dp_1src 110110101100000100101xxxxxxxxxxx
-	(b'\xE7\x2B\xC1\xDA', 'LLIL_INTRINSIC([x7],__pacdza,LLIL_CALL_PARAM([]))'), # pacdza x7
-	(b'\xF7\x2B\xC1\xDA', 'LLIL_INTRINSIC([x23],__pacdza,LLIL_CALL_PARAM([]))'), # pacdza x23
+	(b'\xE7\x2B\xC1\xDA', 'LLIL_INTRINSIC([x7],__pacdza,LLIL_CALL_PARAM([LLIL_REG.q(x7)]))'), # pacdza x7
+	(b'\xF7\x2B\xC1\xDA', 'LLIL_INTRINSIC([x23],__pacdza,LLIL_CALL_PARAM([LLIL_REG.q(x23)]))'), # pacdza x23
 	# PACDZB_64Z_dp_1src 1101101011000001001xxxxxxxxxxxxx
-	(b'\xE6\x2F\xC1\xDA', 'LLIL_INTRINSIC([x6],__pacdzb,LLIL_CALL_PARAM([]))'), # pacdzb x6
-	(b'\xE0\x2F\xC1\xDA', 'LLIL_INTRINSIC([x0],__pacdzb,LLIL_CALL_PARAM([]))'), # pacdzb x0
+	(b'\xE6\x2F\xC1\xDA', 'LLIL_INTRINSIC([x6],__pacdzb,LLIL_CALL_PARAM([LLIL_REG.q(x6)]))'), # pacdzb x6
+	(b'\xE0\x2F\xC1\xDA', 'LLIL_INTRINSIC([x0],__pacdzb,LLIL_CALL_PARAM([LLIL_REG.q(x0)]))'), # pacdzb x0
 	# PACGA_64P_dp_2src 10011010110xxxxx001100xxxxxxxxxx
 	(b'\x22\x30\xCD\x9A', 'LLIL_INTRINSIC([x2],__pacga,LLIL_CALL_PARAM([LLIL_REG.q(x1),LLIL_REG.q(x13)]))'), # pacga x2, x1, x13
 	(b'\x99\x32\xD3\x9A', 'LLIL_INTRINSIC([x25],__pacga,LLIL_CALL_PARAM([LLIL_REG.q(x20),LLIL_REG.q(x19)]))'), # pacga x25, x20, x19
 	# PACIA1716_HI_hints 1101010100000011001000010xxxxxxx
-	(b'\x1F\x21\x03\xD5', 'LLIL_INTRINSIC([x17],__pacia1716,LLIL_CALL_PARAM([LLIL_REG.q(x16)]))'), # pacia1716
+	(b'\x1F\x21\x03\xD5', 'LLIL_INTRINSIC([x17],__pacia1716,LLIL_CALL_PARAM([LLIL_REG.q(x17),LLIL_REG.q(x16)]))'), # pacia1716
 	# PACIAZ_HI_hints 11010101000000110010001100xxxxxx
-	(b'\x1F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__paciaz,LLIL_CALL_PARAM([]))'), # paciaz
+	(b'\x1F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__paciaz,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # paciaz
 	# PACIA_64P_dp_1src 1101101011000001000000xxxxxxxxxx
-	(b'\x4A\x02\xC1\xDA', 'LLIL_INTRINSIC([x10],__pacia,LLIL_CALL_PARAM([LLIL_REG.q(x18)]))'), # pacia x10, x18
-	(b'\xAA\x00\xC1\xDA', 'LLIL_INTRINSIC([x10],__pacia,LLIL_CALL_PARAM([LLIL_REG.q(x5)]))'), # pacia x10, x5
+	(b'\x4A\x02\xC1\xDA', 'LLIL_INTRINSIC([x10],__pacia,LLIL_CALL_PARAM([LLIL_REG.q(x10),LLIL_REG.q(x18)]))'), # pacia x10, x18
+	(b'\xAA\x00\xC1\xDA', 'LLIL_INTRINSIC([x10],__pacia,LLIL_CALL_PARAM([LLIL_REG.q(x10),LLIL_REG.q(x5)]))'), # pacia x10, x5
 	# PACIB1716_HI_hints 110101010000001100100001xxxxxxxx
-	(b'\x5F\x21\x03\xD5', 'LLIL_INTRINSIC([x17],__pacib1716,LLIL_CALL_PARAM([LLIL_REG.q(x16)]))'), # pacib1716
+	(b'\x5F\x21\x03\xD5', 'LLIL_INTRINSIC([x17],__pacib1716,LLIL_CALL_PARAM([LLIL_REG.q(x17),LLIL_REG.q(x16)]))'), # pacib1716
 	# PACIASP_HI_hints 1101010100000011001000110xxxxxxx
 	# writes x30 (after PAC computation), reads sp for modifier
-	(b'\x3F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__paciasp,LLIL_CALL_PARAM([LLIL_REG.q(sp)]))'), # paciasp
+	(b'\x3F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__paciasp,LLIL_CALL_PARAM([LLIL_REG.q(x30),LLIL_REG.q(sp)]))'), # paciasp
 	# PACIBSP_HI_hints 110101010000001100100011xxxxxxxx
-	(b'\x7F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__pacibsp,LLIL_CALL_PARAM([LLIL_REG.q(sp)]))'), # pacibsp
+	(b'\x7F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__pacibsp,LLIL_CALL_PARAM([LLIL_REG.q(x30),LLIL_REG.q(sp)]))'), # pacibsp
 	# PACIBZ_HI_hints 11010101000000110010001101xxxxxx
-	(b'\x5F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__pacibz,LLIL_CALL_PARAM([]))'), # pacibz
+	(b'\x5F\x23\x03\xD5', 'LLIL_INTRINSIC([x30],__pacibz,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # pacibz
 	# PACIB_64P_dp_1src 1101101011000001000001xxxxxxxxxx
-	(b'\x84\x06\xC1\xDA', 'LLIL_INTRINSIC([x4],__pacib,LLIL_CALL_PARAM([LLIL_REG.q(x20)]))'), # pacib x4, x20
-	(b'\x61\x06\xC1\xDA', 'LLIL_INTRINSIC([x1],__pacib,LLIL_CALL_PARAM([LLIL_REG.q(x19)]))'), # pacib x1, x19
+	(b'\x84\x06\xC1\xDA', 'LLIL_INTRINSIC([x4],__pacib,LLIL_CALL_PARAM([LLIL_REG.q(x4),LLIL_REG.q(x20)]))'), # pacib x4, x20
+	(b'\x61\x06\xC1\xDA', 'LLIL_INTRINSIC([x1],__pacib,LLIL_CALL_PARAM([LLIL_REG.q(x1),LLIL_REG.q(x19)]))'), # pacib x1, x19
 	# PACIZA_64Z_dp_1src 110110101100000100100xxxxxxxxxxx
-	(b'\xE3\x23\xC1\xDA', 'LLIL_INTRINSIC([x3],__paciza,LLIL_CALL_PARAM([]))'), # paciza x3
-	(b'\xFE\x23\xC1\xDA', 'LLIL_INTRINSIC([x30],__paciza,LLIL_CALL_PARAM([]))'), # paciza x30
+	(b'\xE3\x23\xC1\xDA', 'LLIL_INTRINSIC([x3],__paciza,LLIL_CALL_PARAM([LLIL_REG.q(x3)]))'), # paciza x3
+	(b'\xFE\x23\xC1\xDA', 'LLIL_INTRINSIC([x30],__paciza,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # paciza x30
 	# PACIZB_64Z_dp_1src 11011010110000010010xxxxxxxxxxxx
-	(b'\xE3\x27\xC1\xDA', 'LLIL_INTRINSIC([x3],__pacizb,LLIL_CALL_PARAM([]))'), # pacizb x3
-	(b'\xE7\x27\xC1\xDA', 'LLIL_INTRINSIC([x7],__pacizb,LLIL_CALL_PARAM([]))'), # pacizb x7
+	(b'\xE3\x27\xC1\xDA', 'LLIL_INTRINSIC([x3],__pacizb,LLIL_CALL_PARAM([LLIL_REG.q(x3)]))'), # pacizb x3
+	(b'\xE7\x27\xC1\xDA', 'LLIL_INTRINSIC([x7],__pacizb,LLIL_CALL_PARAM([LLIL_REG.q(x7)]))'), # pacizb x7
 	# RETAA_64E_branch_reg 11010110010111110000101111111111
 	# (just a return, so function is optimized to nothing)
 	(b'\xFF\x0B\x5F\xD6', ''), # retaa
 	# RETAB_64E_branch_reg 11010110010111110000111111111111
 	(b'\xFF\x0F\x5F\xD6', ''), # retab
 	# XPACD_64Z_dp_1src 110110101100000101000111111xxxxx
-	(b'\xF8\x47\xC1\xDA', 'LLIL_INTRINSIC([x24],__xpacd,LLIL_CALL_PARAM([]))'), # xpacd x24
-	(b'\xED\x47\xC1\xDA', 'LLIL_INTRINSIC([x13],__xpacd,LLIL_CALL_PARAM([]))'), # xpacd x13
+	(b'\xF8\x47\xC1\xDA', 'LLIL_INTRINSIC([x24],__xpacd,LLIL_CALL_PARAM([LLIL_REG.q(x24)]))'), # xpacd x24
+	(b'\xED\x47\xC1\xDA', 'LLIL_INTRINSIC([x13],__xpacd,LLIL_CALL_PARAM([LLIL_REG.q(x13)]))'), # xpacd x13
 	# XPACI_64Z_dp_1src 110110101100000101000xxxxxxxxxxx
-	(b'\xE2\x43\xC1\xDA', 'LLIL_INTRINSIC([x2],__xpaci,LLIL_CALL_PARAM([]))'), # xpaci x2
-	(b'\xE7\x43\xC1\xDA', 'LLIL_INTRINSIC([x7],__xpaci,LLIL_CALL_PARAM([]))'), # xpaci x7
+	(b'\xE2\x43\xC1\xDA', 'LLIL_INTRINSIC([x2],__xpaci,LLIL_CALL_PARAM([LLIL_REG.q(x2)]))'), # xpaci x2
+	(b'\xE7\x43\xC1\xDA', 'LLIL_INTRINSIC([x7],__xpaci,LLIL_CALL_PARAM([LLIL_REG.q(x7)]))'), # xpaci x7
 	# XPACLRI_HI_hints 11010101000000110010000xxxxxxxxx
-	(b'\xFF\x20\x03\xD5', 'LLIL_INTRINSIC([x30],__xpaclri,LLIL_CALL_PARAM([]))'), # xpaclri
+	(b'\xFF\x20\x03\xD5', 'LLIL_INTRINSIC([x30],__xpaclri,LLIL_CALL_PARAM([LLIL_REG.q(x30)]))'), # xpaclri
 	# signed bitfield insert zeros, lsb is position in DESTINATION register (position 0 in source)
 	# strategy: LSL extracted field to the most significant end, then ASR it back
 	(b'\x20\x00\x40\x93', 'LLIL_SET_REG.q(x0,LLIL_ASR.q(LLIL_LSL.q(LLIL_AND.q(LLIL_REG.q(x1),LLIL_CONST.q(0x1)),LLIL_CONST.b(0x3F)),LLIL_CONST.b(0x3F)))'), # sbfiz x0, x1, #0, #1

--- a/il.cpp
+++ b/il.cpp
@@ -1860,7 +1860,7 @@ bool GetLowLevelILForInstruction(
 	case ARM64_PACIB:
 		// <Xd> is address, <Xn> is modifier
 		il.AddInstruction(il.Intrinsic({RegisterOrFlag::Register(REG_O(operand1))},
-		    operation_to_intrinsic(instr.operation), {ILREG_O(operand2)}));
+		    operation_to_intrinsic(instr.operation), {ILREG_O(operand1), ILREG_O(operand2)}));
 		break;
 	case ARM64_PACGA:
 		// <Xd> is address, <Xn>, <Xm> are modifiers, keys
@@ -1872,7 +1872,7 @@ bool GetLowLevelILForInstruction(
 	case ARM64_PACIB1716:
 		// x17 is address, x16 is modifier
 		il.AddInstruction(il.Intrinsic({RegisterOrFlag::Register(REG_X17)},
-		    operation_to_intrinsic(instr.operation), {il.Register(8, REG_X16)}));
+		    operation_to_intrinsic(instr.operation), {il.Register(8, REG_X17), il.Register(8, REG_X16)}));
 		break;
 	case ARM64_AUTDZA:
 	case ARM64_AUTDZB:
@@ -1886,7 +1886,7 @@ bool GetLowLevelILForInstruction(
 	case ARM64_XPACD:
 		// <Xd> is address, modifier is omitted or 0
 		il.AddInstruction(il.Intrinsic(
-		    {RegisterOrFlag::Register(REG_O(operand1))}, operation_to_intrinsic(instr.operation), {}));
+		    {RegisterOrFlag::Register(REG_O(operand1))}, operation_to_intrinsic(instr.operation), {ILREG_O(operand1)}));
 		break;
 	case ARM64_AUTIBZ:
 	case ARM64_PACIAZ:
@@ -1894,14 +1894,14 @@ bool GetLowLevelILForInstruction(
 	case ARM64_XPACLRI:
 		// x30 is address, modifier is omitted or 0
 		il.AddInstruction(il.Intrinsic(
-		    {RegisterOrFlag::Register(REG_X30)}, operation_to_intrinsic(instr.operation), {}));
+		    {RegisterOrFlag::Register(REG_X30)}, operation_to_intrinsic(instr.operation), {il.Register(8, REG_X30)}));
 		break;
 	case ARM64_AUTIBSP:
 	case ARM64_PACIASP:
 	case ARM64_PACIBSP:
 		// x30 is address, sp is modifier
 		il.AddInstruction(il.Intrinsic({RegisterOrFlag::Register(REG_X30)},
-		    operation_to_intrinsic(instr.operation), {il.Register(8, REG_SP)}));
+		    operation_to_intrinsic(instr.operation), {il.Register(8, REG_X30), il.Register(8, REG_SP)}));
 		break;
 	case ARM64_PRFUM:
 	case ARM64_PRFM:


### PR DESCRIPTION
PAC intrinsics _modify_ their destination register Xd, by signing it,
using a modifier in the source register Xn. This means that Xd is not
only written to, but also read from.

A special case is pacga, which takes a source and modifiers in separate
registers.

This adds Xd to the inputs of the PAC intrinsics as the first input.