### PR TITLE
fix: BIC instruction lifting

### DIFF
--- a/arm64test.py
+++ b/arm64test.py
@@ -2544,6 +2544,7 @@ test_cases = \
 						 ' LLIL_SET_FLAG(c,LLIL_CONST(0));' + \
 						 ' LLIL_SET_FLAG(v,LLIL_CONST(0));' + \
 						 ' LLIL_GOTO(8)'), # ccmp w8, #30, #8, mi
+    (b'\x20\x14\x00\x6f', 'LLIL_SET_REG.o(v0, LLIL_AND.o(LLIL_REG.o(v0), LLIL_NOT(LLIL_CONST(1))))'), # bic v0.4s, #0x1
 	(b'\x1F\x20\x03\xD5', 'LLIL_NOP()'), # nop, gets optimized from function
 ]
 

--- a/il.cpp
+++ b/il.cpp
@@ -1262,8 +1262,8 @@ bool GetLowLevelILForInstruction(
 	case ARM64_BIC:
 	case ARM64_BICS:
 		il.AddInstruction(ILSETREG_O(operand1,
-		    il.And(REGSZ_O(operand2), ILREG_O(operand2),
-		        il.Not(REGSZ_O(operand2), ReadILOperand(il, operand3, REGSZ_O(operand2))), SETFLAGS)));
+		    il.And(REGSZ_O(operand1), ILREG_O(operand1),
+		        il.Not(REGSZ_O(operand2), ReadILOperand(il, operand2, REGSZ_O(operand2))), SETFLAGS)));
 		break;
 	case ARM64_CAS:  // these compare-and-swaps can be 32 or 64 bit
 	case ARM64_CASA:


### PR DESCRIPTION
The lifting for `BIC` was referencing an empty operand and and-ing with the wrong operand. I fixed the typos and added a test case that passes.