### PR TITLE
fix bic lift when used with vector regs and immediates

### DIFF
--- a/il.cpp
+++ b/il.cpp
@@ -1261,9 +1261,18 @@ bool GetLowLevelILForInstruction(
 		return false;
 	case ARM64_BIC:
 	case ARM64_BICS:
-		il.AddInstruction(ILSETREG_O(operand1,
-		    il.And(REGSZ_O(operand2), ILREG_O(operand2),
-		        il.Not(REGSZ_O(operand2), ReadILOperand(il, operand3, REGSZ_O(operand2))), SETFLAGS)));
+		switch (instr.encoding) {
+		case ENC_BIC_ASIMDIMM_L_HL:
+		case ENC_BIC_ASIMDIMM_L_SL:
+			il.AddInstruction(ILSETREG_O(operand1,
+				il.And(REGSZ_O(operand1), ILREG_O(operand1),
+					il.Not(REGSZ_O(operand2), ReadILOperand(il, operand2, REGSZ_O(operand2))), SETFLAGS)));
+			break;
+		default:
+			il.AddInstruction(ILSETREG_O(operand1,
+				il.And(REGSZ_O(operand2), ILREG_O(operand2),
+					il.Not(REGSZ_O(operand2), ReadILOperand(il, operand3, REGSZ_O(operand2))), SETFLAGS)));
+		}
 		break;
 	case ARM64_CAS:  // these compare-and-swaps can be 32 or 64 bit
 	case ARM64_CASA:


### PR DESCRIPTION
Uses #118's lift and branches on the encoding.

cc @galenbwill for review. `ENC_BIC_ASIMDIMM_L_HL` is untested.