### PR TITLE
Properly lift BIF and BIT using BSL intrinsic

### DIFF
--- a/neon_intrinsics.cpp
+++ b/neon_intrinsics.cpp
@@ -15372,36 +15372,60 @@ bool NeonGetLowLevelILForInstruction(
 			intrin_id = ARM64_INTRIN_VBIC_S8;  // BIC Vd.8B,Vn.8B,Vm.8B
 		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
 			intrin_id = ARM64_INTRIN_VBICQ_S8;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_S16;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_S16;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_S32;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_S32;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_S64;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_S64;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_U8;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_U8;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_U16;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_U16;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_U32;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_U32;  // BIC Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[1].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBIC_U64;  // BIC Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[1].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBICQ_U64;  // BIC Vd.16B,Vn.16B,Vm.16B
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_input_reg(inputs, il, instr.operands[2]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
+	case ENC_BIT_ASIMDSAME_ONLY:
+		// There is no intrinsic for the bit instruction in the ARM documentation.
+		// Although, the bit instruction is just a bsl instruction with a specific operand order.
+		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
+			intrin_id = ARM64_INTRIN_VBSL_S8;  // BSL Vd.8B,Vn.8B,Vm.8B
+		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
+			intrin_id = ARM64_INTRIN_VBSLQ_S8;  // BSL Vd.16B,Vn.16B,Vm.16B
+		// As per bsl & bit documentation:
+		// 
+		// "Bitwise Select. This instruction sets each bit in the destination SIMD and FP register
+		// to the corresponding bit from the first source SIMD and FP register when the original
+		// destination bit was 1, otherwise from the second source SIMD and FP register."
+		//
+		// and as per bit documentation:
+		// 
+		// "Bitwise Insert if True. This instruction inserts each bit from the first source SIMD
+		// and FP register into the SIMD and FP destination register if the corresponding bit of
+		// the second source SIMD and FP register is 1, otherwise leaves the bit in the destination
+		// register unchanged."
+		//
+		// We can then emulate this behavior using the bsl instruction as follow:
+		add_input_reg(inputs, il, instr.operands[2]);
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_input_reg(inputs, il, instr.operands[0]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
+	case ENC_BIF_ASIMDSAME_ONLY:
+		// There is no intrinsic for the bif instruction in the ARM documentation.
+		// Although, the bif instruction is just a bsl instruction with a specific operand order.
+		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
+			intrin_id = ARM64_INTRIN_VBSL_S8;  // BIF Vd.8B,Vn.8B,Vm.8B
+		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
+			intrin_id = ARM64_INTRIN_VBSLQ_S8;  // BIF Vd.16B,Vn.16B,Vm.16B
+		// As per BSL documentation:
+		// 
+		// "Bitwise Select. This instruction sets each bit in the destination SIMD and FP register
+		// to the corresponding bit from the first source SIMD and FP register when the original
+		// destination bit was 1, otherwise from the second source SIMD and FP register."
+		//
+		// and as per bif documentation:
+		// 
+		// "Bitwise Insert if False. This instruction inserts each bit from the first source SIMD
+		// and FP register into the destination SIMD and FP register if the corresponding bit of the
+		// second source SIMD and FP register is 0, otherwise leaves the bit in the destination
+		// register unchanged."
+		//
+		// We can then emulate this behavior using the bsl instruction as follow:
+		add_input_reg(inputs, il, instr.operands[2]);
+		add_input_reg(inputs, il, instr.operands[0]);
+		add_input_reg(inputs, il, instr.operands[1]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;
 	case ENC_BSL_ASIMDSAME_ONLY:
@@ -15409,58 +15433,6 @@ bool NeonGetLowLevelILForInstruction(
 			intrin_id = ARM64_INTRIN_VBSL_S8;  // BSL Vd.8B,Vn.8B,Vm.8B
 		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
 			intrin_id = ARM64_INTRIN_VBSLQ_S8;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_S16;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_S16;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_S32;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_S32;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_S64;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_S64;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_U8;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_U8;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_U16;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_U16;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_U32;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_U32;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_U64;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_U64;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_P64;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_P64;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_F32;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_F32;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_P8;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_P8;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_P16;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_P16;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_F64;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_F64;  // BSL Vd.16B,Vn.16B,Vm.16B
-		if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
-			intrin_id = ARM64_INTRIN_VBSL_F16;  // BSL Vd.8B,Vn.8B,Vm.8B
-		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
-			intrin_id = ARM64_INTRIN_VBSLQ_F16;  // BSL Vd.16B,Vn.16B,Vm.16B
 		add_input_reg(inputs, il, instr.operands[0]);
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_input_reg(inputs, il, instr.operands[2]);


### PR DESCRIPTION
This PR implements the lifting for [BIF](https://developer.arm.com/documentation/den0018/a/NEON-and-VFP-Instruction-Summary/NEON-logical-and-compare-operations/VBIF) & [BIT](https://developer.arm.com/documentation/den0018/a/NEON-and-VFP-Instruction-Summary/NEON-logical-and-compare-operations/VBIT) neon instructions, which were not supported.

As there's no intrinsic representing these specific instructions, i've emulated this behavior using the `vbsl`/`vbslq` [intrinsic](https://developer.arm.com/documentation/den0018/a/NEON-and-VFP-Instruction-Summary/NEON-logical-and-compare-operations/VBSL).

I've also taken the liberty to cleanup some redundant conditions, which always evaluated to the same result anyway, as the previous value of `intrin_id` is overwritten often. It will also help reduce the size of this file in the long run :)

This disassembly
```
04bf5540  and     v4.16b, v1.16b, v0.16b
04bf5544  ushr    v5.4s, v1.4s, #0x1
04bf5548  cmeq    v4.4s, v4.4s, #0
04bf554c  eor     v6.16b, v5.16b, v2.16b
04bf5550  bsl     v4.16b, v5.16b, v6.16b
04bf5554  and     v5.16b, v4.16b, v0.16b
04bf5558  ushr    v4.4s, v4.4s, #0x1
04bf555c  cmeq    v5.4s, v5.4s, #0
04bf5560  eor     v6.16b, v4.16b, v2.16b
04bf5564  bif     v4.16b, v6.16b, v5.16b
```
Will lift to this LLIL:
```
6185 @ 04bf5540  v4 = v1 & v0
6186 @ 04bf5544  v5.s[0] = v1.s[0] u>> 1
6187 @ 04bf5544  v5.s[1] = v1.s[1] u>> 1
6188 @ 04bf5544  v5.s[2] = v1.s[2] u>> 1
6189 @ 04bf5544  v5.s[3] = v1.s[3] u>> 1
6190 @ 04bf5548  v4 = vceqzq_u32(v4)
6191 @ 04bf554c  v6 = v5 ^ v2
6192 @ 04bf5550  v4 = vbslq_s8(v4, v5, v6)
6193 @ 04bf5554  v5 = v4 & v0
6194 @ 04bf5558  v4.s[0] = v4.s[0] u>> 1
6195 @ 04bf5558  v4.s[1] = v4.s[1] u>> 1
6196 @ 04bf5558  v4.s[2] = v4.s[2] u>> 1
6197 @ 04bf5558  v4.s[3] = v4.s[3] u>> 1
6198 @ 04bf555c  v5 = vceqzq_u32(v5)
6199 @ 04bf5560  v6 = v4 ^ v2
6200 @ 04bf5564  v4 = vbslq_s8(v5, v4, v6)
```