### PR TITLE
Implement lifting for some missing fcvtzs/fcvtzu instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
 	add_library(${PROJECT_NAME} SHARED ${SOURCES})
 endif()
 
+
 if(NOT WIN32)
 	set_source_files_properties(disassembler/arm64dis.c PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
 endif()
@@ -57,6 +58,12 @@ else()
 	endif()
 endif()
 
+IF(DEFINED ENV{ARM64_WARNINGS})
+    MESSAGE(STATUS "ARM64 WARNINGS ON")
+	target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+ELSE()
+    MESSAGE(STATUS "ARM64 WARNINGS OFF")
+ENDIF()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
 	CXX_STANDARD 17

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ success!
 
 And, of course, you can open a test binary in Binary Ninja with this architecture built and activated to see if results are as expected.
 
-## Pull Requests
+## Requirements for Pull Requesters
+
+1. **TEST!** If you're making an architecture or lifter change, add a test case to [arm64test.py](./arm64test.py) that fails before your change and succeeds after your change.
+
+2. **TEST!** If you're making a disassembler change, add a test case to [disassembler/test.py](./disassembler/test.py) that fails before your change and succeeds after your change.
+3. Compile with warnings enabled. Do this cmake invocation: `ARM64_WARNINGS=1 cmake .`
 
 Please follow whatever formatting conventions are present in the file you edit. Pay attention to curly brackets, spacing, tabs vs. spaces, etc.
-
-If you're making an architecture or lifter change, add a test case to [arm64test.py](./arm64test.py) that fails before your change and succeeds after your change.
-
-If you're making a disassembler change, add a test case to [disassembler/test.py](./disassembler/test.py) that fails before your change and succeeds after your change.
 
 When you submit your first PR to one of Vector 35's repositories, you'll receive a notice from [CLA Assistant](https://cla-assistant.io/) that allows you to sign our [Contribution License Agreement](https://binary.ninja/cla.pdf) online.
 
@@ -54,7 +55,7 @@ First, set the `BN_API_PATH` environment variable to the path containing the
 Binary Ninja API source tree.
 
 Run `cmake`. This can be done either from a separate build directory or from the source
-directory. If your app is installed in a non-default location, set BN_INSTALL_DIR in your
+directory. If your app is installed in a non-default location, set `BN_INSTALL_DIR` in your
 cmake invocation, like `cmake -DBN_INSTALL_DIR=/Applications/Binary\ Ninja\ DEV.app/`.
 Once that is complete, run `make` in the build directory to compile the plugin.
 

--- a/arm64test.py
+++ b/arm64test.py
@@ -1062,7 +1062,9 @@ tests_fcvt = [
 	# fcvtzs x15, d0
 	(b'\x0F\x00\x78\x9E', 'LLIL_INTRINSIC([x15],vcvtd_s64_f64,[LLIL_REG.q(d0)])'),
 	# fcvtzs x9, d1
-	(b'\x29\x00\x78\x9E', 'LLIL_INTRINSIC([x9],vcvtd_s64_f64,[LLIL_REG.q(d1)])')
+	(b'\x29\x00\x78\x9E', 'LLIL_INTRINSIC([x9],vcvtd_s64_f64,[LLIL_REG.q(d1)])'),
+	# fcvtzu x10, d0
+	(b'\x0A\x00\x79\x9E', 'LLIL_INTRINSIC([x10],vcvtd_u64_f64,[LLIL_REG.q(d0)])')
 ]
 
 tests_fccmp_fccmpe = [

--- a/arm64test.py
+++ b/arm64test.py
@@ -1066,7 +1066,29 @@ tests_fcvt = [
 	# fcvtzu x10, d0
 	(b'\x0A\x00\x79\x9E', 'LLIL_INTRINSIC([x10],vcvtd_u64_f64,[LLIL_REG.q(d0)])'),
 	# fcvtzu X3, D0, #3
-	(b'\x03\xF4\x59\x9E', 'LLIL_INTRINSIC([x3],vcvtd_n_u64_f64,[LLIL_REG.q(d0),LLIL_CONST(3)])')
+	(b'\x03\xF4\x59\x9E', 'LLIL_INTRINSIC([x3],vcvtd_n_u64_f64,[LLIL_REG.q(d0),LLIL_CONST(3)])'),
+	# fcvtzu v23.4s, v22.4s
+	(b'\xd7\xba\xa1\x6e', 'LLIL_INTRINSIC([v23],vcvtq_u32_f32,[LLIL_REG.o(v22)])'),
+	# fcvtzu v24.2s, v20.2s
+	(b'\x98\xba\xa1\x2e', 'LLIL_INTRINSIC([v24],vcvt_u32_f32,[LLIL_REG.o(v20)])'),
+	# fcvtzu v9.2d, v18.2d
+	(b'\x49\xba\xe1\x6e', 'LLIL_INTRINSIC([v9],vcvtq_u64_f64,[LLIL_REG.o(v18)])'),
+	# fcvtzu v16.4h, v1.4h
+	(b'\x30\xB8\xF9\x2E', 'LLIL_INTRINSIC([v16],vcvt_u16_f16,[LLIL_REG.o(v1)])'),
+	# fcvtzu v28.8h, v5.8h
+	(b'\xBC\xB8\xF9\x6E', 'LLIL_INTRINSIC([v28],vcvtq_u16_f16,[LLIL_REG.o(v5)])'),
+	# fcvtzu v3.2d, v25.2d, #0x2f
+	(b'\x23\xff\x51\x6f', 'LLIL_INTRINSIC([v3],vcvtq_n_u64_f64,[LLIL_REG.o(v25),LLIL_CONST(47)])'),
+	# fcvtzu v16.4s, v14.4s, #0x15
+	(b'\xd0\xfd\x2b\x6f', 'LLIL_INTRINSIC([v16],vcvtq_n_u32_f32,[LLIL_REG.o(v14),LLIL_CONST(21)])'),
+	# fcvtzu v11.2s, v4.2s, #0xb
+	(b'\x8b\xfc\x35\x2f', 'LLIL_INTRINSIC([v11],vcvt_n_u32_f32,[LLIL_REG.o(v4),LLIL_CONST(11)])'),
+	# fcvtzu v11.4h, v20.4h, #2
+	(b'\x8B\xFE\x1E\x2F', 'LLIL_INTRINSIC([v11],vcvt_n_u16_f16,[LLIL_REG.o(v20),LLIL_CONST(2)])'),
+	# fcvtzu v11.8h, v4.8h, #0xb
+	(b'\x8B\xFC\x15\x6F', 'LLIL_INTRINSIC([v11],vcvtq_n_u16_f16,[LLIL_REG.o(v4),LLIL_CONST(11)])'),
+	# fcvtzu w4, s18
+	(b'\x44\x02\x39\x1E', 'LLIL_INTRINSIC([w4],vcvts_u32_f32,[LLIL_REG.d(s18)])')
 ]
 
 tests_fccmp_fccmpe = [

--- a/arm64test.py
+++ b/arm64test.py
@@ -1057,6 +1057,12 @@ tests_fcvt = [
 	(b'\x2F\x42\xE2\x1E', 'LLIL_SET_REG.d(s15,LLIL_FLOAT_CONV.d(LLIL_REG.w(h17)))'),
 	# fcvt s5, h14
 	(b'\xC5\x41\xE2\x1E', 'LLIL_SET_REG.d(s5,LLIL_FLOAT_CONV.d(LLIL_REG.w(h14)))'),
+	# fcvtzs x8, d0
+	(b'\x08\x00\x78\x9E', 'LLIL_INTRINSIC([x8],vcvtd_s64_f64,[LLIL_REG.q(d0)])'),
+	# fcvtzs x15, d0
+	(b'\x0F\x00\x78\x9E', 'LLIL_INTRINSIC([x15],vcvtd_s64_f64,[LLIL_REG.q(d0)])'),
+	# fcvtzs x9, d1
+	(b'\x29\x00\x78\x9E', 'LLIL_INTRINSIC([x9],vcvtd_s64_f64,[LLIL_REG.q(d1)])')
 ]
 
 tests_fccmp_fccmpe = [

--- a/arm64test.py
+++ b/arm64test.py
@@ -1064,7 +1064,9 @@ tests_fcvt = [
 	# fcvtzs x9, d1
 	(b'\x29\x00\x78\x9E', 'LLIL_INTRINSIC([x9],vcvtd_s64_f64,[LLIL_REG.q(d1)])'),
 	# fcvtzu x10, d0
-	(b'\x0A\x00\x79\x9E', 'LLIL_INTRINSIC([x10],vcvtd_u64_f64,[LLIL_REG.q(d0)])')
+	(b'\x0A\x00\x79\x9E', 'LLIL_INTRINSIC([x10],vcvtd_u64_f64,[LLIL_REG.q(d0)])'),
+	# fcvtzu X3, D0, #3
+	(b'\x03\xF4\x59\x9E', 'LLIL_INTRINSIC([x3],vcvtd_n_u64_f64,[LLIL_REG.q(d0),LLIL_CONST(3)])')
 ]
 
 tests_fccmp_fccmpe = [

--- a/disassembler/decode_scratchpad.c
+++ b/disassembler/decode_scratchpad.c
@@ -4376,7 +4376,8 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 	{
 		ArrangementSpec arr_spec = size_spec_method3(ctx->imm5);
 
-		uint64_t INDEX1 = 0, INDEX2 = 0;
+		/*
+		uint64_t INDEX1= 0, INDEX2 = 0;
 		if ((ctx->imm5 & 1) == 1)
 		{
 			INDEX1 = (ctx->imm5 >> 1) & 15;
@@ -4397,6 +4398,7 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 			INDEX1 = (ctx->imm5 >> 4) & 1;
 			INDEX2 = (ctx->imm4 >> 3) & 1;
 		}
+		*/
 
 		// <Vd>.<T>[<index1>],<Vn>.<T>[<index2>]
 		ADD_OPERAND_VREG_T_LANE(ctx->d, arr_spec, ctx->dst_index);
@@ -7891,6 +7893,8 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 		ADD_OPERAND_NAME(prfop);
 		ADD_OPERAND_PRED_REG(ctx->g);
 		ADD_OPERAND_MEM_REG_OFFSET_VL(REGSET_SP, REG_X_BASE, ctx->n, imm);
+
+		/*
 		unsigned factor;
 		switch (instr->encoding)
 		{
@@ -7900,6 +7904,7 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 		default:
 			factor = 1;
 		}
+		*/
 		break;
 	}
 	case ENC_PRFB_I_P_AI_D:

--- a/disassembler/pcode.c
+++ b/disassembler/pcode.c
@@ -582,7 +582,8 @@ uint64_t FPOne(bool sign, int N)
 uint64_t FPTwo(bool sign, int N)
 {
 	// width should be 16, 32, 64
-	int E, F, exp;
+	//int F;
+	int E, exp;
 
 	switch (N)
 	{
@@ -594,7 +595,7 @@ uint64_t FPTwo(bool sign, int N)
 		E = 11;
 	}
 
-	F = N - (E + 1);
+	//F = N - (E + 1);
 	exp = 1 << (E - 1);
 	return (sign << E) | exp;
 }

--- a/neon_intrinsics.cpp
+++ b/neon_intrinsics.cpp
@@ -17128,6 +17128,11 @@ bool NeonGetLowLevelILForInstruction(
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;
+	case ENC_FCVTZU_64D_FLOAT2INT:
+		intrin_id = ARM64_INTRIN_VCVTD_U64_F64;  // FCVTZU Xd,Dn
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
 	case ENC_FCVTZU_32D_FLOAT2INT:
 		intrin_id = ARM64_INTRIN_VCVT_U64_F64;  // FCVTZU Dd,Dn
 		add_input_reg(inputs, il, instr.operands[1]);

--- a/neon_intrinsics.cpp
+++ b/neon_intrinsics.cpp
@@ -17149,23 +17149,43 @@ bool NeonGetLowLevelILForInstruction(
 		add_input_imm(inputs, il, instr.operands[2]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;
-	case ENC_FCVTZU_ASIMDMISCFP16_R:
+	case ENC_FCVTZU_ASIMDMISC_R:
+		// Lift instruction such as fcvtzu v23.4s, v22.4s and fcvtzu v9.2d, v18.2d
 		if (instr.operands[1].arrSpec == ARRSPEC_2SINGLES)
 			intrin_id = ARM64_INTRIN_VCVT_U32_F32;  // FCVTZU Vd.2S,Vn.2S
-		if (instr.operands[1].arrSpec == ARRSPEC_4SINGLES)
+		else if (instr.operands[1].arrSpec == ARRSPEC_4SINGLES)
 			intrin_id = ARM64_INTRIN_VCVTQ_U32_F32;  // FCVTZU Vd.4S,Vn.4S
-		if (instr.operands[1].arrSpec == ARRSPEC_2DOUBLES)
+		else if (instr.operands[1].arrSpec == ARRSPEC_2DOUBLES)
 			intrin_id = ARM64_INTRIN_VCVTQ_U64_F64;  // FCVTZU Vd.2D,Vn.2D
+		else
+			break; // Should be unreachable.
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
+	case ENC_FCVTZU_ASIMDSHF_C:
 		if (instr.operands[1].arrSpec == ARRSPEC_2SINGLES)
 			intrin_id = ARM64_INTRIN_VCVT_N_U32_F32;  // FCVTZU Vd.2S,Vn.2S,#n
-		if (instr.operands[1].arrSpec == ARRSPEC_4SINGLES)
+		else if (instr.operands[1].arrSpec == ARRSPEC_4SINGLES)
 			intrin_id = ARM64_INTRIN_VCVTQ_N_U32_F32;  // FCVTZU Vd.4S,Vn.4S,#n
-		if (instr.operands[1].arrSpec == ARRSPEC_2DOUBLES)
+		else if (instr.operands[1].arrSpec == ARRSPEC_2DOUBLES)
 			intrin_id = ARM64_INTRIN_VCVTQ_N_U64_F64;  // FCVTZU Vd.2D,Vn.2D,#n
-		if (instr.operands[1].arrSpec == ARRSPEC_4HALVES)
+		else if (instr.operands[1].arrSpec == ARRSPEC_4HALVES)
 			intrin_id = ARM64_INTRIN_VCVT_N_U16_F16;  // FCVTZU Vd.4H,Vn.4H,#n
-		if (instr.operands[1].arrSpec == ARRSPEC_8HALVES)
+		else if (instr.operands[1].arrSpec == ARRSPEC_8HALVES)
 			intrin_id = ARM64_INTRIN_VCVTQ_N_U16_F16;  // FCVTZU Vd.8H,Vn.8H,#n
+		else
+			break; // Should be unreachable
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_input_imm(inputs, il, instr.operands[2]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
+	case ENC_FCVTZU_ASIMDMISCFP16_R:
+		if (instr.operands[1].arrSpec == ARRSPEC_4HALVES)
+			intrin_id = ARM64_INTRIN_VCVT_U16_F16;  // FCVTZU Vd.4H,Vn.4H
+		else if (instr.operands[1].arrSpec == ARRSPEC_8HALVES)
+			intrin_id = ARM64_INTRIN_VCVTQ_U16_F16;  // FCVTZU Vd.8H,Vn.8H
+		else
+			break; // Should be unreachable
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;

--- a/neon_intrinsics.cpp
+++ b/neon_intrinsics.cpp
@@ -17143,6 +17143,12 @@ bool NeonGetLowLevelILForInstruction(
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;
+	case ENC_FCVTZU_64D_FLOAT2FIX:
+		intrin_id = ARM64_INTRIN_VCVTD_N_U64_F64;  // FCVTZU Xd, Dn, #n
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_input_imm(inputs, il, instr.operands[2]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
 	case ENC_FCVTZU_ASIMDMISCFP16_R:
 		if (instr.operands[1].arrSpec == ARRSPEC_2SINGLES)
 			intrin_id = ARM64_INTRIN_VCVT_U32_F32;  // FCVTZU Vd.2S,Vn.2S

--- a/neon_intrinsics.cpp
+++ b/neon_intrinsics.cpp
@@ -17080,6 +17080,11 @@ bool NeonGetLowLevelILForInstruction(
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;
+	case ENC_FCVTZS_64D_FLOAT2INT:
+		intrin_id = ARM64_INTRIN_VCVTD_S64_F64;  // FCVTZS Xd,Dn
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
 	case ENC_FCVTZS_32D_FLOAT2INT:
 		intrin_id = ARM64_INTRIN_VCVT_S64_F64;  // FCVTZS Dd,Dn
 		add_input_reg(inputs, il, instr.operands[1]);


### PR DESCRIPTION
This PR implements lifting of some `fcvtzs`/`fcvtzu` instructions. I've mainly followed ARM neon intrinsic documentation to lift them as intrinsic.

I've also fixed a few issues with the original vectorized `FCVTZU` lifting, which led to invalid lifted code.