### PR TITLE
Lift ENC_LD2_ASISDLSE_R2 as intrinsic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
 	add_library(${PROJECT_NAME} SHARED ${SOURCES})
 endif()
 
+
 if(NOT WIN32)
 	set_source_files_properties(disassembler/arm64dis.c PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
 endif()
@@ -57,6 +58,12 @@ else()
 	endif()
 endif()
 
+IF(DEFINED ENV{ARM64_WARNINGS})
+    MESSAGE(STATUS "ARM64 WARNINGS ON")
+	target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+ELSE()
+    MESSAGE(STATUS "ARM64 WARNINGS OFF")
+ENDIF()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
 	CXX_STANDARD 17

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ success!
 
 And, of course, you can open a test binary in Binary Ninja with this architecture built and activated to see if results are as expected.
 
-## Pull Requests
+## Requirements for Pull Requesters
+
+1. **TEST!** If you're making an architecture or lifter change, add a test case to [arm64test.py](./arm64test.py) that fails before your change and succeeds after your change.
+
+2. **TEST!** If you're making a disassembler change, add a test case to [disassembler/test.py](./disassembler/test.py) that fails before your change and succeeds after your change.
+3. Compile with warnings enabled. Do this cmake invocation: `ARM64_WARNINGS=1 cmake .`
 
 Please follow whatever formatting conventions are present in the file you edit. Pay attention to curly brackets, spacing, tabs vs. spaces, etc.
-
-If you're making an architecture or lifter change, add a test case to [arm64test.py](./arm64test.py) that fails before your change and succeeds after your change.
-
-If you're making a disassembler change, add a test case to [disassembler/test.py](./disassembler/test.py) that fails before your change and succeeds after your change.
 
 When you submit your first PR to one of Vector 35's repositories, you'll receive a notice from [CLA Assistant](https://cla-assistant.io/) that allows you to sign our [Contribution License Agreement](https://binary.ninja/cla.pdf) online.
 
@@ -54,7 +55,7 @@ First, set the `BN_API_PATH` environment variable to the path containing the
 Binary Ninja API source tree.
 
 Run `cmake`. This can be done either from a separate build directory or from the source
-directory. If your app is installed in a non-default location, set BN_INSTALL_DIR in your
+directory. If your app is installed in a non-default location, set `BN_INSTALL_DIR` in your
 cmake invocation, like `cmake -DBN_INSTALL_DIR=/Applications/Binary\ Ninja\ DEV.app/`.
 Once that is complete, run `make` in the build directory to compile the plugin.
 

--- a/arm64test.py
+++ b/arm64test.py
@@ -1633,6 +1633,23 @@ tests_ld1 = [
 						 ' LLIL_SET_REG.q(x23,LLIL_ADD.q(LLIL_REG.q(x23),LLIL_REG.q(x23)))'),
 ]
 
+tests_ld2 = [
+	# LD2             {V2.8H-V3.8H}, [X13]
+	(b'\xA2\x85\x40\x4C', 'LLIL_INTRINSIC([v2],vld2q_s16,[LLIL_REG.q(x13)])'),
+	# LD2             {V6.4H-V7.4H}, [X27]
+	(b'\x66\x87\x40\x0C', 'LLIL_INTRINSIC([v6],vld2_s16,[LLIL_REG.q(x27)])'),
+	# LD2             {V7.2S-V8.2S}, [X9]
+	(b'\x27\x89\x40\x0C', 'LLIL_INTRINSIC([v7],vld2_s32,[LLIL_REG.q(x9)])'),
+	# LD2             {V2.4S-V3.4S}, [X24]
+	(b'\x02\x8B\x40\x4C', 'LLIL_INTRINSIC([v2],vld2q_s32,[LLIL_REG.q(x24)])'),
+	# LD2             {V27.8B-V28.8B}, [X7]
+	(b'\xFB\x80\x40\x0C', 'LLIL_INTRINSIC([v27],vld2_s8,[LLIL_REG.q(x7)])'),
+	# LD2             {V8.16B-V9.16B}, [X18]
+	(b'\x48\x82\x40\x4C', 'LLIL_INTRINSIC([v8],vld2q_s8,[LLIL_REG.q(x18)])'),
+	# LD2             {V26.2D-V27.2D}, [X0]
+	(b'\x1A\x8C\x40\x4C', 'LLIL_INTRINSIC([v26],vld2q_s64,[LLIL_REG.q(x0)])')
+]
+
 tests_st1 = [
 	# st1 {v3.2s}, [x27]
 	(b'\x63\x7B\x00\x0C', 'LLIL_STORE.q(LLIL_REG.q(x27),LLIL_REG.q(v3.d[0]))'),
@@ -1829,6 +1846,7 @@ test_cases = \
 	tests_sha + \
 	tests_rev + \
 	tests_ld1 + \
+	tests_ld2 + \
 	tests_st1 + \
 	[
 	# some vectors loads/stores that do not fill the entire register

--- a/disassembler/decode_scratchpad.c
+++ b/disassembler/decode_scratchpad.c
@@ -4376,7 +4376,8 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 	{
 		ArrangementSpec arr_spec = size_spec_method3(ctx->imm5);
 
-		uint64_t INDEX1 = 0, INDEX2 = 0;
+		/*
+		uint64_t INDEX1= 0, INDEX2 = 0;
 		if ((ctx->imm5 & 1) == 1)
 		{
 			INDEX1 = (ctx->imm5 >> 1) & 15;
@@ -4397,6 +4398,7 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 			INDEX1 = (ctx->imm5 >> 4) & 1;
 			INDEX2 = (ctx->imm4 >> 3) & 1;
 		}
+		*/
 
 		// <Vd>.<T>[<index1>],<Vn>.<T>[<index2>]
 		ADD_OPERAND_VREG_T_LANE(ctx->d, arr_spec, ctx->dst_index);
@@ -7891,6 +7893,8 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 		ADD_OPERAND_NAME(prfop);
 		ADD_OPERAND_PRED_REG(ctx->g);
 		ADD_OPERAND_MEM_REG_OFFSET_VL(REGSET_SP, REG_X_BASE, ctx->n, imm);
+
+		/*
 		unsigned factor;
 		switch (instr->encoding)
 		{
@@ -7900,6 +7904,7 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 		default:
 			factor = 1;
 		}
+		*/
 		break;
 	}
 	case ENC_PRFB_I_P_AI_D:

--- a/disassembler/pcode.c
+++ b/disassembler/pcode.c
@@ -582,7 +582,8 @@ uint64_t FPOne(bool sign, int N)
 uint64_t FPTwo(bool sign, int N)
 {
 	// width should be 16, 32, 64
-	int E, F, exp;
+	//int F;
+	int E, exp;
 
 	switch (N)
 	{
@@ -594,7 +595,7 @@ uint64_t FPTwo(bool sign, int N)
 		E = 11;
 	}
 
-	F = N - (E + 1);
+	//F = N - (E + 1);
 	exp = 1 << (E - 1);
 	return (sign << E) | exp;
 }

--- a/neon_intrinsics.cpp
+++ b/neon_intrinsics.cpp
@@ -18215,6 +18215,26 @@ bool NeonGetLowLevelILForInstruction(
 		add_input_reg(inputs, il, instr.operands[1]);
 		add_output_reg(outputs, il, instr.operands[0]);
 		break;
+	case ENC_LD2_ASISDLSE_R2:
+		if (instr.operands[0].arrSpec == ARRSPEC_16BYTES)
+			intrin_id = ARM64_INTRIN_VLD2Q_S8;
+		else if (instr.operands[0].arrSpec == ARRSPEC_8BYTES)
+			intrin_id = ARM64_INTRIN_VLD2_S8;
+		else if (instr.operands[0].arrSpec == ARRSPEC_4HALVES)
+			intrin_id = ARM64_INTRIN_VLD2_S16;
+		else if (instr.operands[0].arrSpec == ARRSPEC_8HALVES)
+			intrin_id = ARM64_INTRIN_VLD2Q_S16;
+		else if (instr.operands[0].arrSpec == ARRSPEC_2SINGLES)
+			intrin_id = ARM64_INTRIN_VLD2_S32;
+		else if (instr.operands[0].arrSpec == ARRSPEC_4SINGLES)
+			intrin_id = ARM64_INTRIN_VLD2Q_S32;
+		else if (instr.operands[0].arrSpec == ARRSPEC_2DOUBLES)
+			intrin_id = ARM64_INTRIN_VLD2Q_S64;
+		else
+			break; // Should be unreachable.
+		add_input_reg(inputs, il, instr.operands[1]);
+		add_output_reg(outputs, il, instr.operands[0]);
+		break;
 	case ENC_MLA_ASIMDELEM_R:
 		if (instr.operands[0].arrSpec == ARRSPEC_4HALVES)
 			intrin_id = ARM64_INTRIN_VMLA_LANE_S16;  // MLA Vd.4H,Vn.4H,Vm.H[lane]


### PR DESCRIPTION
This PR implements the lifting for the `LD2 { Vt.T, Vt2.T }, [Xn|SP] ; No offset` instruction as a neon intrinsic. Tests have been added for each existing case.