### PR TITLE
enforce alignment

### DIFF
--- a/arch_arm64.cpp
+++ b/arch_arm64.cpp
@@ -271,6 +271,10 @@ class Arm64Architecture : public Architecture
 		(void)addr;
 		(void)maxLen;
 		memset(&result, 0, sizeof(result));
+
+		if (addr % 4 != 0)
+			return false;
+
 		if (aarch64_decompose(*(uint32_t*)data, &result, addr) != 0)
 			return false;
 		return true;

--- a/il.cpp
+++ b/il.cpp
@@ -1167,6 +1167,10 @@ bool GetLowLevelILForInstruction(
 	InstructionOperand& operand3 = instr.operands[2];
 	InstructionOperand& operand4 = instr.operands[3];
 
+	if (addr % 4 != 0) {
+		return false;
+	}
+
 	int n_instrs_before = il.GetInstructionCount();
 
 	// printf("%s() operation:%d encoding:%d\n", __func__, instr.operation, instr.encoding);


### PR DESCRIPTION
I have an obfuscated arm64 binary, right now when binja loads this it disassembles and creates tags for unaligned instructions. This results in noise that you cant actually visualize or fix, as these unaligned tags/instructions are not visible/operable though any binary view.

This will mean that unaligned arm64 bytecode in other context (e.g. embedded into a generic payload) will not be able to be disassembled, but I think the net reduction in noise is worse this corner case.