### PR TITLE
Fix invalid and non-portable format string for PRIu64

### DIFF
--- a/disassembler/format.c
+++ b/disassembler/format.c
@@ -420,7 +420,7 @@ uint32_t get_sme_tile(const InstructionOperand *operand, char *outBuffer, uint32
 		if(operand->arrSpec == ARRSPEC_FULL)
 			snprintf(base_offset, sizeof(base_offset), "[%s]", get_register_name(operand->reg[0]));
 		else
-			snprintf(base_offset, sizeof(base_offset), "[%s, #%llu]", get_register_name(operand->reg[0]), operand->immediate);
+			snprintf(base_offset, sizeof(base_offset), "[%s, #%"PRIu64"]", get_register_name(operand->reg[0]), operand->immediate);
 	}
 
 	char *slice = "";
@@ -445,7 +445,7 @@ uint32_t get_indexed_element(const InstructionOperand *operand, char *outBuffer,
 	// make the "{, #<imm>}"
 	char optional_comma_and[32];
 	if(operand->immediate)
-		if(snprintf(optional_comma_and, 32, ", #%llu", operand->immediate) >= 32)
+		if(snprintf(optional_comma_and, 32, ", #%" PRIu64, operand->immediate) >= 32)
 			return FAILED_TO_DISASSEMBLE_OPERAND;
 	
 	// <Pn>.<T>[<Wm>{, #<imm>}]
@@ -462,7 +462,7 @@ uint32_t get_indexed_element(const InstructionOperand *operand, char *outBuffer,
 
 uint32_t get_accum_array(const InstructionOperand *operand, char *outBuffer, uint32_t outBufferSize)
 {
-	if(snprintf(outBuffer, outBufferSize, "ZA[%s, #%llu]",
+	if(snprintf(outBuffer, outBufferSize, "ZA[%s, #%" PRIu64 "]",
 	  get_register_name(operand->reg[0]), operand->immediate
 	  ) >= outBufferSize)
 		return FAILED_TO_DISASSEMBLE_OPERAND;


### PR DESCRIPTION
I'm updating my fork of this repository for radare2 and updating it to fix all the bugs I had patched there. Ideally i would love to use the official repository and stop maintaining my fork but for time-constrain reasons i couldn't push that before.

Iirc this code is autogenerated, so it shouldn't be patched in my side, let me know if there's anything else to tweak.

Thank you